### PR TITLE
Correct triage & assignment message

### DIFF
--- a/front/mobile/lib/api/real.ts
+++ b/front/mobile/lib/api/real.ts
@@ -322,10 +322,8 @@ export class RealEmergencyUpdateListener implements EmergencyUpdateListener {
         if (!storedCase) return;
 
         let newState: EmergencyStatus | null = null;
-        if (msg.event === "EMERGENCY_TRIAGED") {
+        if (msg.event === "EMERGENCY_ASSIGNED") {
           newState = EmergencyStatus.DISPATCHED;
-        } else if (msg.event === "EMERGENCY_ASSIGNED") {
-          newState = EmergencyStatus.ON_ROUTE;
         } else if (msg.event === "EMERGENCY_ARRIVED") {
           newState = EmergencyStatus.ON_SITE;
         } else if (msg.event === "EMERGENCY_TRANSFERRED") {


### PR DESCRIPTION
Just update the emergency state on the citizen side appropriately when triaging and assigning emergencies.