### PR TITLE
Analytics dashboard: real data, heatmap layout, history fixes

### DIFF
--- a/back/core/src/core/domain/entities/historical_emergency.py
+++ b/back/core/src/core/domain/entities/historical_emergency.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict
 
 from core.domain.entities.emergency import Emergency, EmergencyStatus
-from core.domain.entities.medical_center import MedicalCenterInfo
+from core.domain.entities.medical_center import ComplexityLevel, MedicalCenterInfo
 from core.domain.entities.user import GeneralUser, UserRole
 from core.domain.value_objects.location import Location
 from core.domain.value_objects.prehospitalcare_report import AnonimizedPrehospitalCareReport
@@ -27,6 +27,7 @@ class HistoricalEmergency:
     cancelReason: str | None
     prehospitalCareReport: AnonimizedPrehospitalCareReport | None
     timeline: Dict[EmergencyStatus, datetime]
+    complexityLevel: ComplexityLevel | None = None
 
     @classmethod
     def from_emergency(cls, emergency: Emergency):
@@ -42,6 +43,7 @@ class HistoricalEmergency:
             cancelReason=emergency.cancelReason,
             prehospitalCareReport=emergency.prehospitalCareReport,
             timeline=emergency.timeline,
+            complexityLevel=emergency.complexityLevel,
         )
 
 

--- a/back/core/src/core/domain/entities/historical_emergency.py
+++ b/back/core/src/core/domain/entities/historical_emergency.py
@@ -7,6 +7,7 @@ from core.domain.entities.emergency import Emergency, EmergencyStatus
 from core.domain.entities.medical_center import MedicalCenterInfo
 from core.domain.entities.user import GeneralUser, UserRole
 from core.domain.value_objects.location import Location
+from core.domain.value_objects.prehospitalcare_report import AnonimizedPrehospitalCareReport
 from core.domain.value_objects.triage import Triage
 
 
@@ -24,6 +25,7 @@ class HistoricalEmergency:
     assignedTo: GeneralUser | None
     transferedTo: MedicalCenterInfo | None
     cancelReason: str | None
+    prehospitalCareReport: AnonimizedPrehospitalCareReport | None
     timeline: Dict[EmergencyStatus, datetime]
 
     @classmethod
@@ -38,6 +40,7 @@ class HistoricalEmergency:
             operatedBy=emergency.operatedBy,
             assignedTo=emergency.assignedTo,
             cancelReason=emergency.cancelReason,
+            prehospitalCareReport=emergency.prehospitalCareReport,
             timeline=emergency.timeline,
         )
 

--- a/back/core/src/core/domain/tests/test_historical_emergency.py
+++ b/back/core/src/core/domain/tests/test_historical_emergency.py
@@ -1,0 +1,44 @@
+"""Unit tests for the HistoricalEmergency entity.
+
+Focuses on HistoricalEmergency.from_emergency carrying over the
+paramedic's on-site complexity retriage.
+"""
+
+from datetime import datetime
+
+from core.domain.entities.emergency import Emergency
+from core.domain.entities.historical_emergency import HistoricalEmergency
+from core.domain.entities.medical_center import ComplexityLevel
+from core.domain.value_objects.alert import Alert
+from core.domain.value_objects.location import Location
+
+
+def _sample_emergency() -> Emergency:
+    """A freshly received emergency, as produced by Emergency.from_alert."""
+    alert = Alert(
+        location=Location(latitude=12.34, longitude=56.78),
+        generatedOn=datetime(2023, 1, 1, 12, 0, 0),
+        medicalInfo=None,
+    )
+    return Emergency.from_alert(alert)
+
+
+class TestHistoricalEmergencyFromEmergency:
+    """Test cases for HistoricalEmergency.from_emergency."""
+
+    def test_from_emergency_copies_complexity_level(self):
+        """The paramedic's complexity retriage is carried into history."""
+        emergency = _sample_emergency()
+        emergency.complexityLevel = ComplexityLevel.HIGH
+
+        historical = HistoricalEmergency.from_emergency(emergency)
+
+        assert historical.complexityLevel == ComplexityLevel.HIGH
+
+    def test_from_emergency_keeps_complexity_level_none_when_unset(self):
+        """An emergency never retriaged on site archives with None."""
+        emergency = _sample_emergency()
+
+        historical = HistoricalEmergency.from_emergency(emergency)
+
+        assert historical.complexityLevel is None

--- a/front/operator-web/src/App.tsx
+++ b/front/operator-web/src/App.tsx
@@ -3,6 +3,7 @@ import type { OperatorUser } from "@/lib/models";
 import Login from "./Login";
 import Dashboard from "./Dashboard";
 import AnalyticsDashboard from "./views/AnalyticsDashboard";
+import AppButton from "./components/operator/AppButton";
 
 const STORE_KEY = "operator_user";
 
@@ -44,13 +45,12 @@ export default function App() {
     return (
       <div className="flex flex-col h-screen w-screen overflow-hidden bg-op-bg">
         <div className="flex items-center justify-between px-5 py-3 border-b border-op-border bg-op-surface">
-          <span className="text-[15px] font-bold text-op-text">SIEE — Análisis</span>
-          <button
-            className="text-[13px] text-op-error bg-transparent border-0 cursor-pointer"
-            onClick={handleLogout}
-          >
-            Cerrar sesión
-          </button>
+          <span className="text-[15px] font-bold text-op-primary">SIEE — Análisis</span>
+          <AppButton
+            title="Cerrar sesión"
+            variant="primary"
+            onPress={handleLogout}
+          />
         </div>
         <div className="flex-1 flex flex-col min-h-0">
           <AnalyticsDashboard token={user.token} />

--- a/front/operator-web/src/components/analytics/AnalyticsTopBar.tsx
+++ b/front/operator-web/src/components/analytics/AnalyticsTopBar.tsx
@@ -6,8 +6,10 @@ export type AnalyticsView = "analytics" | "history" | "heatmap";
 interface Props {
   view:           AnalyticsView;
   onViewChange:   (v: AnalyticsView) => void;
-  period:         Period;
-  onPeriodChange: (p: Period) => void;
+  analyticsPeriod:         Period;
+  onAnalyticsPeriodChange: (p: Period) => void;
+  historyPeriod:           Period;
+  onHistoryPeriodChange:   (p: Period) => void;
 }
 
 const TABS: { id: AnalyticsView; label: string }[] = [
@@ -29,7 +31,33 @@ const PERIOD_OPTIONS: { value: Period; label: string }[] = [
   { value: "year",  label: "Este año"    },
 ];
 
-export default function AnalyticsTopBar({ view, onViewChange, period, onPeriodChange }: Props) {
+interface PeriodSelectProps {
+  value:    Period;
+  onChange: (p: Period) => void;
+}
+
+function PeriodSelect({ value, onChange }: PeriodSelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as Period)}
+      className="text-[12px] px-[10px] py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text cursor-pointer font-medium"
+    >
+      {PERIOD_OPTIONS.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  );
+}
+
+export default function AnalyticsTopBar({
+  view,
+  onViewChange,
+  analyticsPeriod,
+  onAnalyticsPeriodChange,
+  historyPeriod,
+  onHistoryPeriodChange,
+}: Props) {
   return (
     <div className="h-[52px] bg-op-surface border-b border-op-border flex items-center px-6 justify-between shrink-0">
       <div className="flex items-center gap-4">
@@ -53,28 +81,28 @@ export default function AnalyticsTopBar({ view, onViewChange, period, onPeriodCh
       </div>
 
       <div className="flex items-center gap-[10px]">
-        <select
-          value={period}
-          onChange={(e) => onPeriodChange(e.target.value as Period)}
-          className="text-[12px] px-[10px] py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text cursor-pointer font-medium"
-        >
-          {PERIOD_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
+        {view === "analytics" && (
+          <PeriodSelect value={analyticsPeriod} onChange={onAnalyticsPeriodChange} />
+        )}
 
         {view === "history" && (
           <>
+            <PeriodSelect value={historyPeriod} onChange={onHistoryPeriodChange} />
             <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border-0 bg-op-primary text-white font-semibold cursor-pointer flex items-center gap-[6px]">
               <NavIcon type="history" size={13} />
-              Exportar PDF
+              PDF
             </button>
-
             <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text-sec font-semibold cursor-pointer flex items-center gap-[6px]">
               <NavIcon type="history" size={13} />
               CSV
             </button>
           </>
+        )}
+
+        {view === "heatmap" && (
+          <span className="text-[12px] text-op-text-ter px-[10px] py-[6px] font-medium">
+            Todos los registros
+          </span>
         )}
       </div>
     </div>

--- a/front/operator-web/src/components/analytics/AnalyticsTopBar.tsx
+++ b/front/operator-web/src/components/analytics/AnalyticsTopBar.tsx
@@ -1,7 +1,7 @@
 import NavIcon from "../operator/NavIcon";
 import type { Period } from "../../hooks/analytics/useAnalytics";
 
-export type AnalyticsView = "analytics" | "history";
+export type AnalyticsView = "analytics" | "history" | "heatmap";
 
 interface Props {
   view:           AnalyticsView;
@@ -13,11 +13,13 @@ interface Props {
 const TABS: { id: AnalyticsView; label: string }[] = [
   { id: "analytics", label: "Analítica" },
   { id: "history",   label: "Historial" },
+  { id: "heatmap",   label: "Mapa de calor" },
 ];
 
 const SUBTITLE: Record<AnalyticsView, string> = {
   analytics: "Dashboard de desempeño y patrones de emergencias",
   history:   "Historial completo de emergencias",
+  heatmap:   "Zonas con más emergencias — Envigado",
 };
 
 const PERIOD_OPTIONS: { value: Period; label: string }[] = [
@@ -61,15 +63,19 @@ export default function AnalyticsTopBar({ view, onViewChange, period, onPeriodCh
           ))}
         </select>
 
-        <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border-0 bg-op-primary text-white font-semibold cursor-pointer flex items-center gap-[6px]">
-          <NavIcon type="history" size={13} />
-          Exportar PDF
-        </button>
+        {view === "history" && (
+          <>
+            <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border-0 bg-op-primary text-white font-semibold cursor-pointer flex items-center gap-[6px]">
+              <NavIcon type="history" size={13} />
+              Exportar PDF
+            </button>
 
-        <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text-sec font-semibold cursor-pointer flex items-center gap-[6px]">
-          <NavIcon type="history" size={13} />
-          CSV
-        </button>
+            <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text-sec font-semibold cursor-pointer flex items-center gap-[6px]">
+              <NavIcon type="history" size={13} />
+              CSV
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/front/operator-web/src/components/analytics/HeatMap.tsx
+++ b/front/operator-web/src/components/analytics/HeatMap.tsx
@@ -9,7 +9,7 @@ export default function HeatMap({ points }: Props) {
   const srcDoc = useMemo(() => buildHeatmapHtml(points), [points]);
 
   return (
-    <div className="flex-1 min-h-[560px] rounded-lg overflow-hidden">
+    <div className="h-[560px] rounded-lg overflow-hidden">
       <iframe
         srcDoc={srcDoc}
         className="w-full h-full block border-0"

--- a/front/operator-web/src/components/analytics/HeatMap.tsx
+++ b/front/operator-web/src/components/analytics/HeatMap.tsx
@@ -9,7 +9,7 @@ export default function HeatMap({ points }: Props) {
   const srcDoc = useMemo(() => buildHeatmapHtml(points), [points]);
 
   return (
-    <div className="h-[560px] rounded-lg overflow-hidden">
+    <div className="h-[420px] md:h-[560px] lg:h-[720px] rounded-lg overflow-hidden">
       <iframe
         srcDoc={srcDoc}
         className="w-full h-full block border-0"

--- a/front/operator-web/src/components/analytics/HistoryTable.tsx
+++ b/front/operator-web/src/components/analytics/HistoryTable.tsx
@@ -5,7 +5,7 @@ import NavIcon from "../operator/NavIcon";
 
 interface Props { rows: HistoryRow[] }
 
-const PAGE_SIZE = 14;
+const PAGE_SIZE = 17;
 
 type PageItem = number | "ellipsis";
 
@@ -61,10 +61,12 @@ export default function HistoryTable({ rows }: Props) {
   const rangeTo    = startIdx + visible.length;
   const pageItems  = buildPageList(safePage, totalPages);
 
+  const fillerCount = Math.max(0, PAGE_SIZE - visible.length);
+
   return (
     <div className="bg-op-surface rounded-[10px] border border-op-border overflow-hidden">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-op-border">
+      <div className="flex items-center justify-between px-4 py-[10px] border-b border-op-border">
         <div className="flex items-center gap-2">
           <span className="text-[13px] font-bold text-op-text">Historial de emergencias</span>
           <span className="text-[11px] text-op-text-ter">· {rows.length} registros</span>
@@ -77,10 +79,10 @@ export default function HistoryTable({ rows }: Props) {
             <input
               type="text"
               placeholder="Buscar radicado, operador..."
-              className="text-[12px] pl-7 pr-3 py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text w-[220px] focus:outline-none focus:border-op-primary"
+              className="text-[12px] pl-7 pr-3 py-[5px] rounded-[6px] border border-op-border bg-op-surface text-op-text w-[220px] focus:outline-none focus:border-op-primary"
             />
           </div>
-          <button type="button" className="text-[12px] px-3 py-[6px] rounded-[6px] border border-op-border bg-op-surface text-op-text-sec font-semibold flex items-center gap-[6px] hover:bg-op-bg">
+          <button type="button" className="text-[12px] px-3 py-[5px] rounded-[6px] border border-op-border bg-op-surface text-op-text-sec font-semibold flex items-center gap-[6px] hover:bg-op-bg">
             Filtros
           </button>
         </div>
@@ -90,7 +92,7 @@ export default function HistoryTable({ rows }: Props) {
       <div className="overflow-x-auto">
         <div style={{ minWidth: TOTAL_W }}>
           <div
-            className="grid items-center px-4 py-[10px] border-b border-op-border bg-op-bg gap-3"
+            className="grid items-center px-4 py-[8px] border-b border-op-border bg-op-bg gap-3"
             style={{ gridTemplateColumns: GRID }}
           >
             {COLUMNS.map((c) => (
@@ -103,7 +105,7 @@ export default function HistoryTable({ rows }: Props) {
           {visible.map((row, i) => (
             <div
               key={row.id}
-              className={`grid items-center px-4 py-[11px] gap-3 hover:bg-op-primary-light/40 cursor-pointer transition-colors ${
+              className={`grid items-center px-4 py-[10px] gap-3 h-[40px] hover:bg-op-primary-light/40 cursor-pointer transition-colors ${
                 i < visible.length - 1 ? "border-b border-op-border-light" : ""
               }`}
               style={{ gridTemplateColumns: GRID }}
@@ -122,11 +124,19 @@ export default function HistoryTable({ rows }: Props) {
               <span className="text-[12px] text-op-text font-mono font-bold truncate min-w-0">{row.tTotal}</span>
             </div>
           ))}
+
+          {Array.from({ length: fillerCount }).map((_, i) => (
+            <div
+              key={`filler-${i}`}
+              aria-hidden
+              className="px-4 h-[40px]"
+            />
+          ))}
         </div>
       </div>
 
       {/* Pagination */}
-      <div className="flex items-center justify-between px-4 py-3 border-t border-op-border">
+      <div className="flex items-center justify-between px-4 py-[10px] border-t border-op-border">
         <span className="text-[11px] text-op-text-ter">
           Mostrando {rangeFrom}–{rangeTo} de {rows.length} registros
         </span>

--- a/front/operator-web/src/components/analytics/HistoryTable.tsx
+++ b/front/operator-web/src/components/analytics/HistoryTable.tsx
@@ -32,7 +32,6 @@ const COLUMNS = [
   { key: "operator",   label: "Operador",        w: 150 },
   { key: "opTriage",   label: "Triaje operador", w: 130 },
   { key: "assigned",   label: "Asignado",        w: 140 },
-  { key: "accepted",   label: "Aceptado",        w: 140 },
   { key: "tArrival",   label: "T. llegada",      w: 100 },
   { key: "siteTriage", label: "Triaje sitio",    w: 120 },
   { key: "hospital",   label: "Hospital",        w: 180 },
@@ -115,7 +114,6 @@ export default function HistoryTable({ rows }: Props) {
               <span className="text-[12px] text-op-text font-semibold truncate min-w-0">{row.operator}</span>
               <span className="min-w-0"><Pill variant={row.opTriage.variant}>{row.opTriage.label}</Pill></span>
               <span className="text-[12px] text-op-text-sec truncate min-w-0">{row.assigned}</span>
-              <span className="text-[12px] text-op-text-sec truncate min-w-0">{row.accepted}</span>
               <span className="text-[12px] text-op-text font-mono truncate min-w-0">{row.tArrival}</span>
               <span className="min-w-0"><Pill variant={row.siteTriage.variant}>{row.siteTriage.label}</Pill></span>
               <span className="text-[12px] text-op-text truncate min-w-0">{row.hospital}</span>

--- a/front/operator-web/src/components/analytics/HistoryTable.tsx
+++ b/front/operator-web/src/components/analytics/HistoryTable.tsx
@@ -1,8 +1,30 @@
+import { useEffect, useState } from "react";
 import type { HistoryRow } from "../../hooks/analytics/useHistory";
 import Pill from "../shared/Pill";
 import NavIcon from "../operator/NavIcon";
 
 interface Props { rows: HistoryRow[] }
+
+const PAGE_SIZE = 14;
+
+type PageItem = number | "ellipsis";
+
+/** Returns a windowed page list with at most ~7 visible buttons.
+ *  Always includes the first and last page, plus one neighbor on each
+ *  side of `current`. Gaps of more than one page become an ellipsis. */
+function buildPageList(current: number, total: number): PageItem[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const candidates = new Set<number>([1, total, current - 1, current, current + 1]);
+  const pages = [...candidates].filter((n) => n >= 1 && n <= total).sort((a, b) => a - b);
+  const result: PageItem[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    if (i > 0 && pages[i] - pages[i - 1] > 1) result.push("ellipsis");
+    result.push(pages[i]);
+  }
+  return result;
+}
 
 const COLUMNS = [
   { key: "id",         label: "Radicado",        w: 120 },
@@ -23,6 +45,22 @@ const TOTAL_W = COLUMNS.reduce((a, c) => a + c.w, 0);
 const GRID    = COLUMNS.map((c) => `${c.w}px`).join(" ");
 
 export default function HistoryTable({ rows }: Props) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Reset to the first page whenever the underlying row set changes
+  // (e.g., the analyst picked a different period).
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [rows]);
+
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const safePage   = Math.min(currentPage, totalPages);
+  const startIdx   = (safePage - 1) * PAGE_SIZE;
+  const visible    = rows.slice(startIdx, startIdx + PAGE_SIZE);
+  const rangeFrom  = rows.length === 0 ? 0 : startIdx + 1;
+  const rangeTo    = startIdx + visible.length;
+  const pageItems  = buildPageList(safePage, totalPages);
+
   return (
     <div className="bg-op-surface rounded-[10px] border border-op-border overflow-hidden">
       {/* Toolbar */}
@@ -62,11 +100,11 @@ export default function HistoryTable({ rows }: Props) {
             ))}
           </div>
 
-          {rows.map((row, i) => (
+          {visible.map((row, i) => (
             <div
               key={row.id}
               className={`grid items-center px-4 py-[11px] gap-3 hover:bg-op-primary-light/40 cursor-pointer transition-colors ${
-                i < rows.length - 1 ? "border-b border-op-border-light" : ""
+                i < visible.length - 1 ? "border-b border-op-border-light" : ""
               }`}
               style={{ gridTemplateColumns: GRID }}
             >
@@ -89,21 +127,49 @@ export default function HistoryTable({ rows }: Props) {
 
       {/* Pagination */}
       <div className="flex items-center justify-between px-4 py-3 border-t border-op-border">
-        <span className="text-[11px] text-op-text-ter">Mostrando 1–{rows.length} de 147 registros</span>
+        <span className="text-[11px] text-op-text-ter">
+          Mostrando {rangeFrom}–{rangeTo} de {rows.length} registros
+        </span>
         <div className="flex items-center gap-1">
-          <button type="button" className="w-7 h-7 rounded-[6px] border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg disabled:opacity-40" disabled>‹</button>
-          {[1, 2, 3, 4, 5, 6, 7].map((n) => (
-            <button
-              key={n}
-              type="button"
-              className={`min-w-[28px] h-7 px-2 rounded-[6px] text-[12px] font-semibold ${
-                n === 1 ? "bg-op-primary text-white" : "border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg"
-              }`}
-            >
-              {n}
-            </button>
-          ))}
-          <button type="button" className="w-7 h-7 rounded-[6px] border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg">›</button>
+          <button
+            type="button"
+            onClick={() => setCurrentPage(safePage - 1)}
+            disabled={safePage === 1}
+            className="w-7 h-7 rounded-[6px] border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+          >
+            ‹
+          </button>
+          {pageItems.map((item, i) =>
+            item === "ellipsis" ? (
+              <span
+                key={`ellipsis-${i}`}
+                className="min-w-[28px] h-7 px-1 text-[12px] text-op-text-ter flex items-center justify-center select-none"
+              >
+                …
+              </span>
+            ) : (
+              <button
+                key={item}
+                type="button"
+                onClick={() => setCurrentPage(item)}
+                className={`min-w-[28px] h-7 px-2 rounded-[6px] text-[12px] font-semibold cursor-pointer ${
+                  item === safePage
+                    ? "bg-op-primary text-white"
+                    : "border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg"
+                }`}
+              >
+                {item}
+              </button>
+            ),
+          )}
+          <button
+            type="button"
+            onClick={() => setCurrentPage(safePage + 1)}
+            disabled={safePage === totalPages}
+            className="w-7 h-7 rounded-[6px] border border-op-border bg-op-surface text-op-text-sec hover:bg-op-bg disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+          >
+            ›
+          </button>
         </div>
       </div>
     </div>

--- a/front/operator-web/src/components/analytics/OperatorsTable.tsx
+++ b/front/operator-web/src/components/analytics/OperatorsTable.tsx
@@ -4,7 +4,7 @@ interface Props {
   operators: OperatorData[];
 }
 
-const HEADER_COLS = ["#", "Operador", "Atend.", "T.prom", ""];
+const HEADER_COLS = ["#", "Operador", "Atend.", "T.prom"];
 
 function initials(name: string): string {
   return name
@@ -20,7 +20,7 @@ export default function OperatorsTable({ operators }: Props) {
 
   return (
     <div>
-      <div className="grid [grid-template-columns:24px_1fr_60px_50px_14px] py-[6px] border-b border-op-border gap-[6px]">
+      <div className="grid [grid-template-columns:24px_1fr_60px_50px] py-[6px] border-b border-op-border gap-[6px]">
         {HEADER_COLS.map((h, i) => (
           <span key={i} className="text-[9px] font-bold text-op-text-ter tracking-[0.5px] uppercase">{h}</span>
         ))}
@@ -29,7 +29,7 @@ export default function OperatorsTable({ operators }: Props) {
       {operators.map((op, i) => (
         <div
           key={i}
-          className="grid [grid-template-columns:24px_1fr_60px_50px_14px] py-2 items-center gap-[6px]"
+          className="grid [grid-template-columns:24px_1fr_60px_50px] py-2 items-center gap-[6px]"
           style={{ borderBottom: i < operators.length - 1 ? "1px solid #f0f0f0" : "none" }}
         >
           <span className="text-[11px] text-op-text-ter font-semibold">{i + 1}</span>
@@ -54,10 +54,6 @@ export default function OperatorsTable({ operators }: Props) {
           </div>
 
           <span className="text-[12px] text-op-text-sec">{op.avgTime}</span>
-
-          <span
-            className={`inline-block w-2 h-2 rounded-full justify-self-center ${op.active ? "bg-op-success" : "bg-op-text-ter"}`}
-          />
         </div>
       ))}
     </div>

--- a/front/operator-web/src/components/analytics/StackedPipelineBar.tsx
+++ b/front/operator-web/src/components/analytics/StackedPipelineBar.tsx
@@ -2,6 +2,7 @@ import type { PipelineStage } from "../../hooks/analytics/useAnalytics";
 
 interface Props {
   stages: PipelineStage[];
+  stdev: string;
 }
 
 function parseSeconds(time: string): number {
@@ -15,7 +16,7 @@ function formatTotal(sec: number): string {
   return `${sec}s`;
 }
 
-export default function StackedPipelineBar({ stages }: Props) {
+export default function StackedPipelineBar({ stages, stdev }: Props) {
   const segs = stages.map((s) => ({ ...s, sec: parseSeconds(s.time) }));
   const total = segs.reduce((a, b) => a + b.sec, 0);
 
@@ -63,7 +64,7 @@ export default function StackedPipelineBar({ stages }: Props) {
       {/* Std dev footer */}
       <div className="mt-3 px-3 py-2 bg-op-bg rounded-[7px] flex justify-between items-center">
         <span className="text-[11px] text-op-text-sec">Desviación estándar</span>
-        <span className="text-[12px] font-bold text-op-text">±2m 15s</span>
+        <span className="text-[12px] font-bold text-op-text">±{stdev}</span>
       </div>
     </div>
   );

--- a/front/operator-web/src/components/analytics/TopLocationsList.tsx
+++ b/front/operator-web/src/components/analytics/TopLocationsList.tsx
@@ -1,0 +1,96 @@
+import type { TopLocationsState } from "../../hooks/analytics/useTopLocations";
+
+interface Props {
+  state: TopLocationsState;
+}
+
+function subtitleFor(state: TopLocationsState): string {
+  if (state.loading && state.rows.length === 0) return "Cargando ubicaciones…";
+  if (state.loading) return `Actualizando… ${state.rows.length} de 5`;
+  return `${state.rows.length} zonas`;
+}
+
+export default function TopLocationsList({ state }: Props) {
+  const { loading, rows } = state;
+  const topCount = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  const showSkeleton = loading && rows.length === 0;
+  const showEmpty    = !loading && rows.length === 0;
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-baseline justify-between mb-3">
+        <span className="text-[13px] font-bold text-op-text">
+          Top 5 ubicaciones con más incidentes
+        </span>
+        <span className="text-[11px] text-op-text-ter">{subtitleFor(state)}</span>
+      </div>
+
+      {showSkeleton && (
+        <div className="flex flex-col">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className={`grid items-center py-[10px] gap-3 ${
+                i < 4 ? "border-b border-op-border-light" : ""
+              }`}
+              style={{ gridTemplateColumns: "36px 1fr auto" }}
+            >
+              <div className="w-7 h-7 rounded-full bg-op-bg animate-pulse" />
+              <div className="h-3 rounded bg-op-bg animate-pulse" />
+              <div className="h-3 w-20 rounded bg-op-bg animate-pulse" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showEmpty && (
+        <div className="py-6 text-center text-[12px] text-op-text-ter">
+          Sin datos de ubicaciones disponibles
+        </div>
+      )}
+
+      {!showSkeleton && !showEmpty && (
+        <div className="flex flex-col">
+          {rows.map((row, i) => {
+            const pct = topCount > 0 ? (row.count / topCount) * 100 : 0;
+            return (
+              <div
+                key={row.label}
+                className={`py-[10px] ${
+                  i < rows.length - 1 ? "border-b border-op-border-light" : ""
+                }`}
+              >
+                <div
+                  className="grid items-center gap-3"
+                  style={{ gridTemplateColumns: "36px 1fr auto" }}
+                >
+                  <div
+                    className={`w-7 h-7 rounded-full flex items-center justify-center text-[12px] font-bold ${
+                      row.rank === 1
+                        ? "bg-op-primary text-white"
+                        : "bg-op-bg border border-op-border text-op-text-sec"
+                    }`}
+                  >
+                    {row.rank}
+                  </div>
+                  <span className="text-[13px] text-op-text font-semibold truncate min-w-0">
+                    {row.label}
+                  </span>
+                  <span className="text-[12px] text-op-text-sec font-mono">
+                    {row.count} incidentes
+                  </span>
+                </div>
+                <div className="mt-[6px] h-[3px] rounded-full bg-op-primary-light overflow-hidden">
+                  <div
+                    className="h-full bg-op-primary"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/operator-web/src/components/analytics/TrendChart.tsx
+++ b/front/operator-web/src/components/analytics/TrendChart.tsx
@@ -1,21 +1,10 @@
-import { useState } from "react";
-import type { TrendData, TrendView } from "../../hooks/analytics/useAnalytics";
+import type { TrendData } from "../../hooks/analytics/useAnalytics";
 
 interface Props {
-  trends: TrendData;
+  trend: TrendData;
 }
 
-const TABS: { key: TrendView; label: string }[] = [
-  { key: "hourly",  label: "Horas" },
-  { key: "daily",   label: "Días"  },
-  { key: "monthly", label: "Meses" },
-];
-
 const PRIMARY = "#257985";
-
-const HOURLY_LABELS  = Array.from({ length: 24 }, (_, i) => (i % 3 === 0 ? `${i}h` : ""));
-const DAILY_LABELS   = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
-const MONTHLY_LABELS = ["E","F","M","A","M","J","J","A","S","O","N","D"];
 
 function BarChart({ data, labels, height = 130 }: { data: number[]; labels: string[]; height?: number }) {
   const max = Math.max(...data, 1);
@@ -51,37 +40,15 @@ function BarChart({ data, labels, height = 130 }: { data: number[]; labels: stri
   );
 }
 
-export default function TrendChart({ trends }: Props) {
-  const [view, setView] = useState<TrendView>("hourly");
-
-  const chartData   = view === "daily" ? trends.daily : view === "monthly" ? trends.monthly : trends.hourly;
-  const chartLabels = view === "daily" ? DAILY_LABELS : view === "monthly" ? MONTHLY_LABELS : HOURLY_LABELS;
-  const peak        = Math.max(...chartData);
-  const avg         = Math.round(chartData.reduce((a, b) => a + b, 0) / chartData.length);
+export default function TrendChart({ trend }: Props) {
+  const peak = Math.max(...trend.data);
+  const avg  = Math.round(trend.data.reduce((a, b) => a + b, 0) / trend.data.length);
 
   return (
     <div>
-      {/* Tabs */}
-      <div className="flex gap-1 mb-[10px]">
-        {TABS.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setView(t.key)}
-            className={`text-[11px] px-[10px] py-1 rounded-[5px] border cursor-pointer font-semibold ${
-              view === t.key
-                ? "border-op-primary bg-op-primary-light text-op-primary"
-                : "border-op-border bg-op-surface text-op-text-sec"
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
       {/* Chart area */}
       <div className="min-h-[130px]">
-        <BarChart data={chartData} labels={chartLabels} height={130} />
+        <BarChart data={trend.data} labels={trend.labels} height={130} />
       </div>
 
       {/* Footer */}

--- a/front/operator-web/src/components/analytics/TrendChart.tsx
+++ b/front/operator-web/src/components/analytics/TrendChart.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { operatorStatusColors as S } from "@/lib/themes/Colors";
 import type { TrendData, TrendView } from "../../hooks/analytics/useAnalytics";
 
 interface Props {
@@ -10,7 +9,6 @@ const TABS: { key: TrendView; label: string }[] = [
   { key: "hourly",  label: "Horas" },
   { key: "daily",   label: "Días"  },
   { key: "monthly", label: "Meses" },
-  { key: "kpis",    label: "KPIs"  },
 ];
 
 const PRIMARY = "#257985";
@@ -18,13 +16,6 @@ const PRIMARY = "#257985";
 const HOURLY_LABELS  = Array.from({ length: 24 }, (_, i) => (i % 3 === 0 ? `${i}h` : ""));
 const DAILY_LABELS   = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
 const MONTHLY_LABELS = ["E","F","M","A","M","J","J","A","S","O","N","D"];
-
-const KPI_SERIES = [
-  { key: "triaje"     as const, label: "Triaje",     color: S.triaged.accent  },
-  { key: "asignacion" as const, label: "Asignación", color: S.assigned.accent },
-  { key: "llegada"    as const, label: "Llegada",    color: S.onSite.accent   },
-  { key: "total"      as const, label: "Total",      color: PRIMARY           },
-];
 
 function BarChart({ data, labels, height = 130 }: { data: number[]; labels: string[]; height?: number }) {
   const max = Math.max(...data, 1);
@@ -60,32 +51,6 @@ function BarChart({ data, labels, height = 130 }: { data: number[]; labels: stri
   );
 }
 
-function Sparkline({ data, color }: { data: number[]; color: string }) {
-  const w = 200, h = 26;
-  const max = Math.max(...data, 1);
-  const min = Math.min(...data, 0);
-  const range = max - min || 1;
-  const pts = data
-    .map((v, i) => {
-      const x = (i / (data.length - 1)) * w;
-      const y = h - ((v - min) / range) * (h - 4) - 2;
-      return `${x},${y}`;
-    })
-    .join(" ");
-  return (
-    <svg width={w} height={h} style={{ display: "block" }}>
-      <polyline
-        points={pts}
-        fill="none"
-        stroke={color}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 export default function TrendChart({ trends }: Props) {
   const [view, setView] = useState<TrendView>("hourly");
 
@@ -116,33 +81,20 @@ export default function TrendChart({ trends }: Props) {
 
       {/* Chart area */}
       <div className="min-h-[130px]">
-        {view === "kpis" ? (
-          <div>
-            {KPI_SERIES.map((s) => (
-              <div key={s.key} className="flex items-center gap-2 mb-1">
-                <span className="text-[10px] text-op-text-sec w-[65px] text-right shrink-0">{s.label}</span>
-                <Sparkline data={trends.kpis[s.key]} color={s.color} />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <BarChart data={chartData} labels={chartLabels} height={130} />
-        )}
+        <BarChart data={chartData} labels={chartLabels} height={130} />
       </div>
 
-      {/* Footer — only shown for bar views */}
-      {view !== "kpis" && (
-        <div className="mt-2 flex gap-4">
-          <div className="flex items-center gap-[5px]">
-            <span className="text-[10px] text-op-text-ter">Pico:</span>
-            <span className="text-[11px] font-bold text-op-text">{peak}</span>
-          </div>
-          <div className="flex items-center gap-[5px]">
-            <span className="text-[10px] text-op-text-ter">Promedio:</span>
-            <span className="text-[11px] font-bold text-op-text">{avg}</span>
-          </div>
+      {/* Footer */}
+      <div className="mt-2 flex gap-4">
+        <div className="flex items-center gap-[5px]">
+          <span className="text-[10px] text-op-text-ter">Pico:</span>
+          <span className="text-[11px] font-bold text-op-text">{peak}</span>
         </div>
-      )}
+        <div className="flex items-center gap-[5px]">
+          <span className="text-[10px] text-op-text-ter">Promedio:</span>
+          <span className="text-[11px] font-bold text-op-text">{avg}</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/front/operator-web/src/hooks/analytics/analyticsTrends.ts
+++ b/front/operator-web/src/hooks/analytics/analyticsTrends.ts
@@ -1,5 +1,10 @@
 import type { BackendEmergency } from "./emergencyStream";
-import type { TrendData } from "./useAnalytics";
+import type { Period, TrendData } from "./useAnalytics";
+
+const DAY_MS = 86_400_000;
+
+const DAILY_LABELS   = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
+const MONTHLY_LABELS = ["E", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 
 function receivedDate(e: BackendEmergency): Date | null {
   const iso = e.timeline?.["RECEIVED"];
@@ -8,66 +13,65 @@ function receivedDate(e: BackendEmergency): Date | null {
   return isNaN(d.getTime()) ? null : d;
 }
 
-/** Seconds between two timeline statuses, or null if either is missing
- *  or the span is non-positive. */
-function diffSeconds(
-  tl: Record<string, string> | undefined,
-  fromStatus: string,
-  toStatus: string,
-): number | null {
-  if (!tl) return null;
-  const a = tl[fromStatus];
-  const b = tl[toStatus];
-  if (!a || !b) return null;
-  const ms = new Date(b).getTime() - new Date(a).getTime();
-  return ms > 0 ? ms / 1000 : null;
-}
-
-function average(values: number[]): number {
-  if (values.length === 0) return 0;
-  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
-}
-
-/** Bucket emergencies into the hourly/daily/monthly counts and the
- *  monthly KPI averages consumed by TrendChart. */
-export function buildTrendData(emergencies: BackendEmergency[]): TrendData {
-  const hourly  = Array<number>(24).fill(0);
-  const daily   = Array<number>(7).fill(0);
-  const monthly = Array<number>(12).fill(0);
-
-  const triajeByMonth     = Array.from({ length: 12 }, () => [] as number[]);
-  const asignacionByMonth = Array.from({ length: 12 }, () => [] as number[]);
-  const llegadaByMonth    = Array.from({ length: 12 }, () => [] as number[]);
-  const totalByMonth      = Array.from({ length: 12 }, () => [] as number[]);
-
+/** Count emergencies into `size` buckets via `indexOf`; skip out-of-range. */
+function bucketCounts(
+  emergencies: BackendEmergency[],
+  size: number,
+  indexOf: (d: Date) => number,
+): number[] {
+  const counts = Array<number>(size).fill(0);
   for (const e of emergencies) {
     const d = receivedDate(e);
     if (!d) continue;
-
-    hourly[d.getHours()]++;
-    daily[(d.getDay() + 6) % 7]++;   // Mon=0 ... Sun=6
-    monthly[d.getMonth()]++;
-
-    const month      = d.getMonth();
-    const triaje     = diffSeconds(e.timeline, "RECEIVED", "TAKEN");
-    const asignacion = diffSeconds(e.timeline, "TRIAGED", "ASSIGNED");
-    const llegada    = diffSeconds(e.timeline, "ASSIGNED", "ON_SITE");
-    const total      = diffSeconds(e.timeline, "RECEIVED", "CLOSED");
-    if (triaje     !== null) triajeByMonth[month].push(triaje);
-    if (asignacion !== null) asignacionByMonth[month].push(asignacion);
-    if (llegada    !== null) llegadaByMonth[month].push(llegada);
-    if (total      !== null) totalByMonth[month].push(total);
+    const i = indexOf(d);
+    if (i >= 0 && i < size) counts[i]++;
   }
+  return counts;
+}
 
-  return {
-    hourly,
-    daily,
-    monthly,
-    kpis: {
-      triaje:     triajeByMonth.map(average),
-      asignacion: asignacionByMonth.map(average),
-      llegada:    llegadaByMonth.map(average),
-      total:      totalByMonth.map(average),
-    },
-  };
+function buildHourly(emergencies: BackendEmergency[]): TrendData {
+  const data = bucketCounts(emergencies, 24, (d) => d.getHours());
+  const labels = Array.from({ length: 24 }, (_, i) => (i % 3 === 0 ? `${i}h` : ""));
+  return { data, labels };
+}
+
+function buildWeekly(emergencies: BackendEmergency[]): TrendData {
+  const data = bucketCounts(emergencies, 7, (d) => (d.getDay() + 6) % 7);
+  return { data, labels: DAILY_LABELS };
+}
+
+function buildYearly(emergencies: BackendEmergency[]): TrendData {
+  const data = bucketCounts(emergencies, 12, (d) => d.getMonth());
+  return { data, labels: MONTHLY_LABELS };
+}
+
+function buildDaysOfMonth(
+  emergencies: BackendEmergency[],
+  range: { since: string; to: string },
+): TrendData {
+  const sinceMs = new Date(range.since).getTime();
+  const toMs    = new Date(range.to).getTime();
+  const days    = Math.max(1, Math.ceil((toMs - sinceMs) / DAY_MS));
+  const data    = bucketCounts(emergencies, days, (d) =>
+    Math.floor((d.getTime() - sinceMs) / DAY_MS),
+  );
+  const labels = Array.from({ length: days }, (_, i) => {
+    if (i % 5 !== 0) return "";
+    return String(new Date(sinceMs + i * DAY_MS).getDate());
+  });
+  return { data, labels };
+}
+
+/** Resolve the single bar-chart view that matches the dashboard period. */
+export function buildTrendData(
+  emergencies: BackendEmergency[],
+  period: Period,
+  range: { since: string; to: string },
+): TrendData {
+  switch (period) {
+    case "today": return buildHourly(emergencies);
+    case "week":  return buildWeekly(emergencies);
+    case "year":  return buildYearly(emergencies);
+    case "month": return buildDaysOfMonth(emergencies, range);
+  }
 }

--- a/front/operator-web/src/hooks/analytics/analyticsTrends.ts
+++ b/front/operator-web/src/hooks/analytics/analyticsTrends.ts
@@ -1,0 +1,73 @@
+import type { BackendEmergency } from "./emergencyStream";
+import type { TrendData } from "./useAnalytics";
+
+function receivedDate(e: BackendEmergency): Date | null {
+  const iso = e.timeline?.["RECEIVED"];
+  if (!iso) return null;
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/** Seconds between two timeline statuses, or null if either is missing
+ *  or the span is non-positive. */
+function diffSeconds(
+  tl: Record<string, string> | undefined,
+  fromStatus: string,
+  toStatus: string,
+): number | null {
+  if (!tl) return null;
+  const a = tl[fromStatus];
+  const b = tl[toStatus];
+  if (!a || !b) return null;
+  const ms = new Date(b).getTime() - new Date(a).getTime();
+  return ms > 0 ? ms / 1000 : null;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+}
+
+/** Bucket emergencies into the hourly/daily/monthly counts and the
+ *  monthly KPI averages consumed by TrendChart. */
+export function buildTrendData(emergencies: BackendEmergency[]): TrendData {
+  const hourly  = Array<number>(24).fill(0);
+  const daily   = Array<number>(7).fill(0);
+  const monthly = Array<number>(12).fill(0);
+
+  const triajeByMonth     = Array.from({ length: 12 }, () => [] as number[]);
+  const asignacionByMonth = Array.from({ length: 12 }, () => [] as number[]);
+  const llegadaByMonth    = Array.from({ length: 12 }, () => [] as number[]);
+  const totalByMonth      = Array.from({ length: 12 }, () => [] as number[]);
+
+  for (const e of emergencies) {
+    const d = receivedDate(e);
+    if (!d) continue;
+
+    hourly[d.getHours()]++;
+    daily[(d.getDay() + 6) % 7]++;   // Mon=0 ... Sun=6
+    monthly[d.getMonth()]++;
+
+    const month      = d.getMonth();
+    const triaje     = diffSeconds(e.timeline, "RECEIVED", "TAKEN");
+    const asignacion = diffSeconds(e.timeline, "TRIAGED", "ASSIGNED");
+    const llegada    = diffSeconds(e.timeline, "ASSIGNED", "ON_SITE");
+    const total      = diffSeconds(e.timeline, "RECEIVED", "CLOSED");
+    if (triaje     !== null) triajeByMonth[month].push(triaje);
+    if (asignacion !== null) asignacionByMonth[month].push(asignacion);
+    if (llegada    !== null) llegadaByMonth[month].push(llegada);
+    if (total      !== null) totalByMonth[month].push(total);
+  }
+
+  return {
+    hourly,
+    daily,
+    monthly,
+    kpis: {
+      triaje:     triajeByMonth.map(average),
+      asignacion: asignacionByMonth.map(average),
+      llegada:    llegadaByMonth.map(average),
+      total:      totalByMonth.map(average),
+    },
+  };
+}

--- a/front/operator-web/src/hooks/analytics/emergencyStream.ts
+++ b/front/operator-web/src/hooks/analytics/emergencyStream.ts
@@ -33,6 +33,7 @@ export interface BackendEmergency {
   location?:     BackendLocation | null;
   filingNumber?: number;
   triage?:       BackendTriage | null;
+  complexityLevel?: number | null;
   finalStatus?:  string;
   operatedBy?:   BackendUser | null;
   assignedTo?:   BackendUser | null;

--- a/front/operator-web/src/hooks/analytics/emergencyStream.ts
+++ b/front/operator-web/src/hooks/analytics/emergencyStream.ts
@@ -1,0 +1,79 @@
+import { BASE_URL } from "@/lib/api/config";
+
+export interface BackendLocation {
+  latitude:  number;
+  longitude: number;
+}
+
+export interface BackendTriage {
+  bleeding?:             boolean;
+  dizziness?:            boolean;
+  blurred_vision?:       boolean;
+  unconscious?:          boolean;
+  difficulty_breathing?: boolean;
+  fracture?:             boolean;
+  chest_pain?:           boolean;
+  numbness_limbs?:       boolean;
+  [key: string]: boolean | undefined;
+}
+
+export interface BackendUser {
+  id?:    string;
+  name?:  string;
+  email?: string;
+}
+
+export interface BackendMedicalCenter {
+  id?:   string;
+  name?: string;
+}
+
+export interface BackendEmergency {
+  id:            string;
+  location?:     BackendLocation | null;
+  filingNumber?: number;
+  triage?:       BackendTriage | null;
+  finalStatus?:  string;
+  operatedBy?:   BackendUser | null;
+  assignedTo?:   BackendUser | null;
+  transferedTo?: BackendMedicalCenter | null;
+  cancelReason?: string | null;
+  timeline?:     Record<string, string>;
+}
+
+/** Parse the /historic/emergency response, which may arrive as a JSON
+ *  array or as NDJSON (one JSON object per line). */
+export function parseEmergencyStream(text: string): BackendEmergency[] {
+  if (text.trimStart().startsWith("[")) {
+    try {
+      return JSON.parse(text) as BackendEmergency[];
+    } catch {
+      // Fall through to line-by-line parsing.
+    }
+  }
+
+  const out: BackendEmergency[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed) as BackendEmergency);
+    } catch {
+      // Skip malformed lines silently.
+    }
+  }
+  return out;
+}
+
+export async function fetchEmergencies(
+  token: string,
+  since: string,
+  to: string,
+): Promise<BackendEmergency[]> {
+  const url = `${BASE_URL}/api/v1/historic/emergency?since=${encodeURIComponent(since)}&to=${encodeURIComponent(to)}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`emergency stream fetch failed: ${res.status}`);
+  return parseEmergencyStream(await res.text());
+}

--- a/front/operator-web/src/hooks/analytics/useAnalytics.ts
+++ b/front/operator-web/src/hooks/analytics/useAnalytics.ts
@@ -56,7 +56,6 @@ export interface AnalyticsData {
   trends: TrendData;
   operators: OperatorData[];
   comparative: ComparativeItem[];
-  heatmapPoints: [number, number, number][];
 }
 
 // ---------------------------------------------------------------------------
@@ -105,15 +104,6 @@ const MOCK_COMPARATIVE: ComparativeItem[] = [
   { label: "Casos críticos",    current: "32",        prev: "28",        delta: "+14%", positive: false },
 ];
 
-const MOCK_HEATMAP: [number, number, number][] = [
-  [6.1710,-75.5890,0.8],[6.1680,-75.5920,0.6],[6.1650,-75.5840,0.9],[6.1730,-75.5870,0.4],
-  [6.1695,-75.5950,0.7],[6.1720,-75.5860,0.5],[6.1700,-75.5900,1.0],[6.1660,-75.5880,0.3],
-  [6.1740,-75.5910,0.6],[6.1685,-75.5850,0.8],[6.1715,-75.5930,0.5],[6.1670,-75.5870,0.7],
-  [6.1705,-75.5845,0.9],[6.1690,-75.5915,0.4],[6.1725,-75.5880,0.6],[6.1665,-75.5900,0.3],
-  [6.1735,-75.5855,0.7],[6.1675,-75.5935,0.5],[6.1710,-75.5870,0.8],[6.1698,-75.5862,0.6],
-  [6.1755,-75.5895,0.5],[6.1645,-75.5905,0.4],[6.1720,-75.5945,0.6],[6.1690,-75.5835,0.7],
-];
-
 const MOCK_DATA: AnalyticsData = {
   emergencyCount: 147,
   kpis: MOCK_KPIS,
@@ -121,7 +111,6 @@ const MOCK_DATA: AnalyticsData = {
   trends: MOCK_TRENDS,
   operators: MOCK_OPERATORS,
   comparative: MOCK_COMPARATIVE,
-  heatmapPoints: MOCK_HEATMAP,
 };
 
 // ---------------------------------------------------------------------------
@@ -255,7 +244,6 @@ function mapStatisticsToAnalytics(stats: BackendStatistics): AnalyticsData {
     trends,
     operators: MOCK_OPERATORS,
     comparative,
-    heatmapPoints: MOCK_HEATMAP,
   };
 }
 

--- a/front/operator-web/src/hooks/analytics/useAnalytics.ts
+++ b/front/operator-web/src/hooks/analytics/useAnalytics.ts
@@ -6,7 +6,7 @@ import { useEmergencyStream } from "./useEmergencyStream";
 import { buildTrendData } from "./analyticsTrends";
 
 export type Period = "today" | "week" | "month" | "year";
-export type TrendView = "hourly" | "daily" | "monthly" | "kpis";
+export type TrendView = "hourly" | "daily" | "monthly";
 
 export interface KpiData {
   label: string;

--- a/front/operator-web/src/hooks/analytics/useAnalytics.ts
+++ b/front/operator-web/src/hooks/analytics/useAnalytics.ts
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { BASE_URL } from "@/lib/api/config";
 import { operatorUiColors as U, operatorStatusColors as S } from "@/lib/themes/Colors";
 import type { NavIconType } from "../../components/operator/NavIcon";
+import { useEmergencyStream } from "./useEmergencyStream";
+import { buildTrendData } from "./analyticsTrends";
 
 export type Period = "today" | "week" | "month" | "year";
 export type TrendView = "hourly" | "daily" | "monthly" | "kpis";
@@ -38,7 +40,6 @@ export interface OperatorData {
   name: string;
   attended: number;
   avgTime: string;
-  active: boolean;
 }
 
 export interface ComparativeItem {
@@ -51,6 +52,7 @@ export interface ComparativeItem {
 
 export interface AnalyticsData {
   emergencyCount: number;
+  stdev: string;
   kpis: KpiData[];
   pipeline: PipelineStage[];
   trends: TrendData;
@@ -58,60 +60,11 @@ export interface AnalyticsData {
   comparative: ComparativeItem[];
 }
 
-// ---------------------------------------------------------------------------
-// Mock data — shown when the backend is unavailable or user is not ANALYST.
-// ---------------------------------------------------------------------------
-
-const MOCK_KPIS: KpiData[] = [
-  { label: "Tiempo triaje",      value: "1m 24s",  avg: "1m 30s",  delta: -4,  icon: "triage",   color: S.triaged.accent  },
-  { label: "Tiempo asignación",  value: "2m 10s",  avg: "2m 45s",  delta: -21, icon: "assign",   color: S.assigned.accent },
-  { label: "Tiempo llegada",     value: "8m 32s",  avg: "9m 00s",  delta: -5,  icon: "location", color: S.onSite.accent   },
-  { label: "Tiempo total",       value: "18m 45s", avg: "22m 10s", delta: -15, icon: "history",  color: U.primary         },
-  { label: "Promedio en cola",   value: "45s",     avg: "1m 02s",  delta: -27, icon: "alerts",   color: S.received.accent },
-];
-
-const MOCK_PIPELINE: PipelineStage[] = [
-  { stage: "Recibida",          time: "10s", color: S.received.accent },
-  { stage: "Pend. asignación",  time: "40s", color: S.triaged.accent  },
-  { stage: "Transfer. a sitio", time: "2m",  color: S.assigned.accent },
-  { stage: "En sitio",          time: "3m",  color: S.onSite.accent   },
-  { stage: "Transfer. centro",  time: "3m",  color: S.closed.accent   },
-];
-
-const MOCK_TRENDS: TrendData = {
-  hourly:  [3,5,2,1,0,1,4,8,14,18,22,19,15,12,16,20,24,18,14,10,7,5,4,2],
-  daily:   [42,38,55,61,48,35,29],
-  monthly: [320,290,340,380,410,365,398,420,445,390,370,350],
-  kpis: {
-    triaje:     [95,88,84,82,80,84,78,85,82,80,84,78],
-    asignacion: [180,165,150,140,135,130,128,132,126,130,128,125],
-    llegada:    [560,540,520,510,515,505,512,508,500,510,505,498],
-    total:      [1200,1180,1150,1130,1120,1125,1110,1100,1115,1105,1095,1080],
-  },
-};
-
-const MOCK_OPERATORS: OperatorData[] = [
-  { name: "Juan Martínez",   attended: 145, avgTime: "16m", active: true  },
-  { name: "Laura Gómez",     attended: 132, avgTime: "18m", active: true  },
-  { name: "Carlos Restrepo", attended: 128, avgTime: "15m", active: false },
-  { name: "Ana Pérez",       attended: 118, avgTime: "20m", active: true  },
-  { name: "Pedro López",     attended:  95, avgTime: "22m", active: false },
-];
-
-const MOCK_COMPARATIVE: ComparativeItem[] = [
-  { label: "Total emergencias", current: "147",      prev: "131",      delta: "+12%", positive: true  },
-  { label: "Tiempo respuesta",  current: "18m 45s",  prev: "22m 10s",  delta: "-15%", positive: true  },
-  { label: "Casos críticos",    current: "32",        prev: "28",        delta: "+14%", positive: false },
-];
-
-const MOCK_DATA: AnalyticsData = {
-  emergencyCount: 147,
-  kpis: MOCK_KPIS,
-  pipeline: MOCK_PIPELINE,
-  trends: MOCK_TRENDS,
-  operators: MOCK_OPERATORS,
-  comparative: MOCK_COMPARATIVE,
-};
+export interface AnalyticsState {
+  loading: boolean;
+  data:    AnalyticsData | null;
+  error:   string | null;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -129,6 +82,14 @@ function periodToRange(period: Period): { since: string; to: string } {
   return { since: since.toISOString(), to: to.toISOString() };
 }
 
+/** The equal-length window immediately preceding the current period. */
+function previousPeriodRange(period: Period): { since: string; to: string } {
+  const { since, to } = periodToRange(period);
+  const sinceMs = new Date(since).getTime();
+  const span = new Date(to).getTime() - sinceMs;
+  return { since: new Date(sinceMs - span).toISOString(), to: since };
+}
+
 function fmtSeconds(s: number): string {
   if (!isFinite(s) || s <= 0) return "—";
   if (s < 60) return `${Math.round(s)}s`;
@@ -137,114 +98,118 @@ function fmtSeconds(s: number): string {
   return sec > 0 ? `${m}m ${sec}s` : `${m}m`;
 }
 
+function pctDelta(current: number, prev: number): number {
+  if (prev <= 0) return 0;
+  return Math.round(((current - prev) / prev) * 100);
+}
+
+function signedPct(current: number, prev: number): string {
+  if (prev <= 0) return "";
+  const pct = Math.round(((current - prev) / prev) * 100);
+  return `${pct >= 0 ? "+" : ""}${pct}%`;
+}
+
+interface OperatorRankingEntry {
+  operator_id: string;
+  name: string;
+  count: number;
+  averageHandlingTime: number;
+}
+
+interface ParamedicRankingEntry {
+  paramedic_id: string;
+  name: string;
+  count: number;
+  averageHandlingTime: number;
+}
+
 interface BackendStatistics {
   since: string;
   to: string;
   emergencyCount: number;
   averageTotalTime: number;
+  averageTotalTimeStdev: number;
   averageTimeline: Record<string, number>;
   hourHistogram: Record<string, number>;
+  operatorRanking: OperatorRankingEntry[];
+  paramedicRanking: ParamedicRankingEntry[];
 }
 
-function mapStatisticsToAnalytics(stats: BackendStatistics): AnalyticsData {
-  const tl = stats.averageTimeline;
+function buildKpis(
+  cur: BackendStatistics,
+  prev: BackendStatistics | null,
+): KpiData[] {
+  const ct = cur.averageTimeline;
+  const pt = prev?.averageTimeline ?? {};
+  const hasPrev = prev !== null && prev.emergencyCount > 0;
 
-  const kpis: KpiData[] = [
-    {
-      label: "Tiempo triaje",
-      value: fmtSeconds(tl["RECEIVED"] ?? 0),
-      avg: fmtSeconds((tl["RECEIVED"] ?? 0) * 1.07),
-      delta: -7,
-      icon: "triage",
-      color: S.triaged.accent,
-    },
-    {
-      label: "Tiempo asignación",
-      value: fmtSeconds(tl["TRIAGED"] ?? 0),
-      avg: fmtSeconds((tl["TRIAGED"] ?? 0) * 1.1),
-      delta: -10,
-      icon: "assign",
-      color: S.assigned.accent,
-    },
-    {
-      label: "Tiempo llegada",
-      value: fmtSeconds(tl["ASSIGNED"] ?? 0),
-      avg: fmtSeconds((tl["ASSIGNED"] ?? 0) * 1.06),
-      delta: -6,
-      icon: "location",
-      color: S.onSite.accent,
-    },
-    {
-      label: "Tiempo total",
-      value: fmtSeconds(stats.averageTotalTime),
-      avg: fmtSeconds(stats.averageTotalTime * 1.12),
-      delta: -12,
-      icon: "history",
-      color: U.primary,
-    },
-    {
-      label: "Promedio en cola",
-      value: fmtSeconds(tl["RECEIVED"] ?? 0),
-      avg: fmtSeconds((tl["RECEIVED"] ?? 0) * 1.15),
-      delta: -15,
-      icon: "alerts",
-      color: S.received.accent,
-    },
+  const mk = (
+    label: string,
+    curVal: number,
+    prevVal: number,
+    icon: NavIconType,
+    color: string,
+  ): KpiData => ({
+    label,
+    value: fmtSeconds(curVal),
+    avg: hasPrev ? fmtSeconds(prevVal) : "—",
+    delta: hasPrev ? pctDelta(curVal, prevVal) : 0,
+    icon,
+    color,
+  });
+
+  return [
+    mk("Tiempo triaje",     ct["RECEIVED"] ?? 0,  pt["RECEIVED"] ?? 0,  "triage",   S.triaged.accent),
+    mk("Tiempo asignación", ct["TRIAGED"]  ?? 0,  pt["TRIAGED"]  ?? 0,  "assign",   S.assigned.accent),
+    mk("Tiempo llegada",    ct["ASSIGNED"] ?? 0,  pt["ASSIGNED"] ?? 0,  "location", S.onSite.accent),
+    mk("Tiempo total",      cur.averageTotalTime, prev?.averageTotalTime ?? 0, "history", U.primary),
+    mk("Promedio en cola",  ct["RECEIVED"] ?? 0,  pt["RECEIVED"] ?? 0,  "alerts",   S.received.accent),
   ];
+}
 
-  const pipeline: PipelineStage[] = [
+function buildPipeline(cur: BackendStatistics): PipelineStage[] {
+  const tl = cur.averageTimeline;
+  return [
     { stage: "Recibida",          time: fmtSeconds(tl["RECEIVED"] ?? 0),    color: S.received.accent },
     { stage: "Pend. asignación",  time: fmtSeconds(tl["TRIAGED"] ?? 0),     color: S.triaged.accent  },
     { stage: "Transfer. a sitio", time: fmtSeconds(tl["ASSIGNED"] ?? 0),    color: S.assigned.accent },
     { stage: "En sitio",          time: fmtSeconds(tl["ON_SITE"] ?? 0),     color: S.onSite.accent   },
     { stage: "Transfer. centro",  time: fmtSeconds(tl["IN_TRANSFER"] ?? 0), color: S.closed.accent   },
   ];
+}
 
-  // Expand 2-hour histogram buckets into 24-element hourly array.
-  const hourly: number[] = Array(24).fill(0);
-  for (const [h, count] of Object.entries(stats.hourHistogram)) {
-    const hour = parseInt(h);
-    if (hour < 24) hourly[hour] = count;
-    if (hour + 1 < 24) hourly[hour + 1] = count;
-  }
+function buildOperators(cur: BackendStatistics): OperatorData[] {
+  return cur.operatorRanking.map((o) => ({
+    name: o.name,
+    attended: o.count,
+    avgTime: fmtSeconds(o.averageHandlingTime),
+  }));
+}
 
-  const trends: TrendData = {
-    hourly,
-    daily: MOCK_TRENDS.daily,
-    monthly: MOCK_TRENDS.monthly,
-    kpis: {
-      triaje:     Array(12).fill(Math.round(tl["RECEIVED"] ?? 0)),
-      asignacion: Array(12).fill(Math.round(tl["TRIAGED"] ?? 0)),
-      llegada:    Array(12).fill(Math.round(tl["ASSIGNED"] ?? 0)),
-      total:      Array(12).fill(Math.round(stats.averageTotalTime)),
-    },
-  };
+function buildComparative(
+  cur: BackendStatistics,
+  prev: BackendStatistics | null,
+): ComparativeItem[] {
+  const hasPrev = prev !== null && prev.emergencyCount > 0;
+  const countDelta = hasPrev ? cur.emergencyCount - prev!.emergencyCount : 0;
+  const timeDelta  = hasPrev ? cur.averageTotalTime - prev!.averageTotalTime : 0;
 
-  const comparative: ComparativeItem[] = [
+  return [
     {
       label: "Total emergencias",
-      current: String(stats.emergencyCount),
-      prev: "—",
-      delta: "",
-      positive: true,
+      current: String(cur.emergencyCount),
+      prev: hasPrev ? String(prev!.emergencyCount) : "—",
+      delta: hasPrev ? signedPct(cur.emergencyCount, prev!.emergencyCount) : "",
+      positive: countDelta >= 0,
     },
     {
       label: "Tiempo respuesta",
-      current: fmtSeconds(stats.averageTotalTime),
-      prev: "—",
-      delta: "",
-      positive: true,
+      current: fmtSeconds(cur.averageTotalTime),
+      prev: hasPrev ? fmtSeconds(prev!.averageTotalTime) : "—",
+      delta: hasPrev ? signedPct(cur.averageTotalTime, prev!.averageTotalTime) : "",
+      positive: timeDelta <= 0,
     },
   ];
-
-  return {
-    emergencyCount: stats.emergencyCount,
-    kpis,
-    pipeline,
-    trends,
-    operators: MOCK_OPERATORS,
-    comparative,
-  };
 }
 
 async function fetchStatistics(
@@ -260,22 +225,64 @@ async function fetchStatistics(
   return res.json() as Promise<BackendStatistics>;
 }
 
-export function useAnalytics(period: Period, token?: string): AnalyticsData {
-  const [data, setData] = useState<AnalyticsData>(MOCK_DATA);
+interface StatsState {
+  loading: boolean;
+  current: BackendStatistics | null;
+  previous: BackendStatistics | null;
+  error: string | null;
+}
+
+export function useAnalytics(period: Period, token?: string): AnalyticsState {
+  const curRange  = useMemo(() => periodToRange(period), [period]);
+  const prevRange = useMemo(() => previousPeriodRange(period), [period]);
+
+  const stream = useEmergencyStream(curRange.since, curRange.to, token);
+
+  const [stats, setStats] = useState<StatsState>({
+    loading: !!token,
+    current: null,
+    previous: null,
+    error: null,
+  });
 
   useEffect(() => {
-    if (!token) return;
-    const { since, to } = periodToRange(period);
+    if (!token) {
+      setStats({ loading: false, current: null, previous: null, error: null });
+      return;
+    }
     let cancelled = false;
-    fetchStatistics(token, since, to)
-      .then((stats) => {
-        if (!cancelled) setData(mapStatisticsToAnalytics(stats));
+    setStats({ loading: true, current: null, previous: null, error: null });
+    Promise.all([
+      fetchStatistics(token, curRange.since, curRange.to),
+      fetchStatistics(token, prevRange.since, prevRange.to),
+    ])
+      .then(([current, previous]) => {
+        if (!cancelled) setStats({ loading: false, current, previous, error: null });
       })
-      .catch(() => {
-        if (!cancelled) setData(MOCK_DATA);
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "fetch failed";
+        setStats({ loading: false, current: null, previous: null, error: message });
       });
     return () => { cancelled = true; };
-  }, [period, token]);
+  }, [token, curRange.since, curRange.to, prevRange.since, prevRange.to]);
 
-  return data;
+  const data = useMemo<AnalyticsData | null>(() => {
+    if (!stats.current) return null;
+    return {
+      emergencyCount: stats.current.emergencyCount,
+      stdev: fmtSeconds(stats.current.averageTotalTimeStdev),
+      kpis: buildKpis(stats.current, stats.previous),
+      pipeline: buildPipeline(stats.current),
+      trends: buildTrendData(stream.emergencies),
+      operators: buildOperators(stats.current),
+      comparative: buildComparative(stats.current, stats.previous),
+    };
+  }, [stats.current, stats.previous, stream.emergencies]);
+
+  return {
+    loading: stats.loading || stream.loading,
+    data,
+    error: stats.error ?? stream.error,
+  };
 }

--- a/front/operator-web/src/hooks/analytics/useAnalytics.ts
+++ b/front/operator-web/src/hooks/analytics/useAnalytics.ts
@@ -6,7 +6,6 @@ import { useEmergencyStream } from "./useEmergencyStream";
 import { buildTrendData } from "./analyticsTrends";
 
 export type Period = "today" | "week" | "month" | "year";
-export type TrendView = "hourly" | "daily" | "monthly";
 
 export interface KpiData {
   label: string;
@@ -25,15 +24,8 @@ export interface PipelineStage {
 }
 
 export interface TrendData {
-  hourly: number[];
-  daily: number[];
-  monthly: number[];
-  kpis: {
-    triaje: number[];
-    asignacion: number[];
-    llegada: number[];
-    total: number[];
-  };
+  data: number[];
+  labels: string[];
 }
 
 export interface OperatorData {
@@ -55,7 +47,7 @@ export interface AnalyticsData {
   stdev: string;
   kpis: KpiData[];
   pipeline: PipelineStage[];
-  trends: TrendData;
+  trend: TrendData;
   operators: OperatorData[];
   comparative: ComparativeItem[];
 }
@@ -274,11 +266,11 @@ export function useAnalytics(period: Period, token?: string): AnalyticsState {
       stdev: fmtSeconds(stats.current.averageTotalTimeStdev),
       kpis: buildKpis(stats.current, stats.previous),
       pipeline: buildPipeline(stats.current),
-      trends: buildTrendData(stream.emergencies),
+      trend: buildTrendData(stream.emergencies, period, curRange),
       operators: buildOperators(stats.current),
       comparative: buildComparative(stats.current, stats.previous),
     };
-  }, [stats.current, stats.previous, stream.emergencies]);
+  }, [stats.current, stats.previous, stream.emergencies, period, curRange]);
 
   return {
     loading: stats.loading || stream.loading,

--- a/front/operator-web/src/hooks/analytics/useEmergencyStream.ts
+++ b/front/operator-web/src/hooks/analytics/useEmergencyStream.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { fetchEmergencies, type BackendEmergency } from "./emergencyStream";
+
+export interface EmergencyStreamState {
+  loading:     boolean;
+  emergencies: BackendEmergency[];
+  error:       string | null;
+}
+
+/** Fetches the historic emergency stream for a date range.
+ *  `since` and `to` MUST be stable across renders (memoize them in the
+ *  caller) — they are effect dependencies. */
+export function useEmergencyStream(
+  since: string,
+  to: string,
+  token?: string,
+): EmergencyStreamState {
+  const [state, setState] = useState<EmergencyStreamState>({
+    loading:     !!token,
+    emergencies: [],
+    error:       null,
+  });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ loading: false, emergencies: [], error: null });
+      return;
+    }
+    let cancelled = false;
+    setState({ loading: true, emergencies: [], error: null });
+    fetchEmergencies(token, since, to)
+      .then((emergencies) => {
+        if (!cancelled) setState({ loading: false, emergencies, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "fetch failed";
+        setState({ loading: false, emergencies: [], error: message });
+      });
+    return () => { cancelled = true; };
+  }, [since, to, token]);
+
+  return state;
+}

--- a/front/operator-web/src/hooks/analytics/useHeatmap.ts
+++ b/front/operator-web/src/hooks/analytics/useHeatmap.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { BASE_URL } from "@/lib/api/config";
+
+export interface HeatmapState {
+  loading: boolean;
+  points:  [number, number, number][];
+  error:   string | null;
+}
+
+// Wide range that comfortably covers the entire SIEE history.
+const SINCE_EPOCH = "2000-01-01T00:00:00Z";
+
+interface BackendLocation {
+  latitude:  number;
+  longitude: number;
+}
+
+interface BackendEmergency {
+  location?: BackendLocation | null;
+}
+
+function consume(e: BackendEmergency, out: [number, number, number][]): void {
+  const loc = e.location;
+  if (!loc) return;
+  if (typeof loc.latitude !== "number" || typeof loc.longitude !== "number") return;
+  out.push([loc.latitude, loc.longitude, 1.0]);
+}
+
+function parseStream(text: string): [number, number, number][] {
+  const points: [number, number, number][] = [];
+
+  // Handle both JSON array and NDJSON (FastAPI streaming response).
+  if (text.trimStart().startsWith("[")) {
+    try {
+      const arr = JSON.parse(text) as BackendEmergency[];
+      for (const e of arr) consume(e, points);
+      return points;
+    } catch {
+      // Fall through to line-by-line parsing if the JSON array parse fails.
+    }
+  }
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      consume(JSON.parse(trimmed) as BackendEmergency, points);
+    } catch {
+      // Skip malformed lines silently.
+    }
+  }
+  return points;
+}
+
+async function fetchAllPoints(token: string): Promise<[number, number, number][]> {
+  const now = new Date().toISOString();
+  const url = `${BASE_URL}/api/v1/historic/emergency?since=${encodeURIComponent(SINCE_EPOCH)}&to=${encodeURIComponent(now)}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`heatmap fetch failed: ${res.status}`);
+  return parseStream(await res.text());
+}
+
+export function useHeatmap(token?: string): HeatmapState {
+  const [state, setState] = useState<HeatmapState>({
+    loading: !!token,
+    points:  [],
+    error:   null,
+  });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ loading: false, points: [], error: null });
+      return;
+    }
+    let cancelled = false;
+    setState({ loading: true, points: [], error: null });
+    fetchAllPoints(token)
+      .then((points) => {
+        if (!cancelled) setState({ loading: false, points, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "fetch failed";
+        setState({ loading: false, points: [], error: message });
+      });
+    return () => { cancelled = true; };
+  }, [token]);
+
+  return state;
+}

--- a/front/operator-web/src/hooks/analytics/useHeatmap.ts
+++ b/front/operator-web/src/hooks/analytics/useHeatmap.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { BASE_URL } from "@/lib/api/config";
+import { useMemo } from "react";
+import { useEmergencyStream } from "./useEmergencyStream";
 
 export interface HeatmapState {
   loading: boolean;
@@ -10,83 +10,21 @@ export interface HeatmapState {
 // Wide range that comfortably covers the entire SIEE history.
 const SINCE_EPOCH = "2000-01-01T00:00:00Z";
 
-interface BackendLocation {
-  latitude:  number;
-  longitude: number;
-}
-
-interface BackendEmergency {
-  location?: BackendLocation | null;
-}
-
-function consume(e: BackendEmergency, out: [number, number, number][]): void {
-  const loc = e.location;
-  if (!loc) return;
-  if (typeof loc.latitude !== "number" || typeof loc.longitude !== "number") return;
-  out.push([loc.latitude, loc.longitude, 1.0]);
-}
-
-function parseStream(text: string): [number, number, number][] {
-  const points: [number, number, number][] = [];
-
-  // Handle both JSON array and NDJSON (FastAPI streaming response).
-  if (text.trimStart().startsWith("[")) {
-    try {
-      const arr = JSON.parse(text) as BackendEmergency[];
-      for (const e of arr) consume(e, points);
-      return points;
-    } catch {
-      // Fall through to line-by-line parsing if the JSON array parse fails.
-    }
-  }
-
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      consume(JSON.parse(trimmed) as BackendEmergency, points);
-    } catch {
-      // Skip malformed lines silently.
-    }
-  }
-  return points;
-}
-
-async function fetchAllPoints(token: string): Promise<[number, number, number][]> {
-  const now = new Date().toISOString();
-  const url = `${BASE_URL}/api/v1/historic/emergency?since=${encodeURIComponent(SINCE_EPOCH)}&to=${encodeURIComponent(now)}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`heatmap fetch failed: ${res.status}`);
-  return parseStream(await res.text());
-}
-
 export function useHeatmap(token?: string): HeatmapState {
-  const [state, setState] = useState<HeatmapState>({
-    loading: !!token,
-    points:  [],
-    error:   null,
-  });
+  // Computed once on mount so the stream effect does not re-fire.
+  const to = useMemo(() => new Date().toISOString(), []);
+  const { loading, emergencies, error } = useEmergencyStream(SINCE_EPOCH, to, token);
 
-  useEffect(() => {
-    if (!token) {
-      setState({ loading: false, points: [], error: null });
-      return;
+  const points = useMemo<[number, number, number][]>(() => {
+    const out: [number, number, number][] = [];
+    for (const e of emergencies) {
+      const loc = e.location;
+      if (!loc) continue;
+      if (typeof loc.latitude !== "number" || typeof loc.longitude !== "number") continue;
+      out.push([loc.latitude, loc.longitude, 1.0]);
     }
-    let cancelled = false;
-    setState({ loading: true, points: [], error: null });
-    fetchAllPoints(token)
-      .then((points) => {
-        if (!cancelled) setState({ loading: false, points, error: null });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : "fetch failed";
-        setState({ loading: false, points: [], error: message });
-      });
-    return () => { cancelled = true; };
-  }, [token]);
+    return out;
+  }, [emergencies]);
 
-  return state;
+  return { loading, points, error };
 }

--- a/front/operator-web/src/hooks/analytics/useHistory.ts
+++ b/front/operator-web/src/hooks/analytics/useHistory.ts
@@ -82,13 +82,17 @@ function triageToPriority(triage: BackendTriage | null): PillData {
 /** Maps the paramedic's on-site complexity retriage to a pill.
  *  `complexityLevel` is the backend ComplexityLevel enum: 0 BASIC,
  *  1 INTERMEDIATE, 2 HIGH. `null`/undefined means the paramedic never
- *  retriaged the emergency (e.g. it was canceled before their arrival). */
+ *  retriaged the emergency (e.g. it was canceled before their arrival).
+ *
+ *  Labels share the operator-triage vocabulary (Crítico/Urgente/Leve)
+ *  so an analyst can compare both columns at a glance: same severity,
+ *  same word — the paramedic's call simply overrides the operator's. */
 function complexityToSiteTriage(level?: number | null): PillData {
   switch (level) {
-    case 2:  return { label: "Alto",       variant: "critical" };
-    case 1:  return { label: "Intermedio", variant: "urgent" };
-    case 0:  return { label: "Básico",     variant: "light" };
-    default: return { label: "—",          variant: "cancelled" };
+    case 2:  return { label: "Crítico", variant: "critical" };
+    case 1:  return { label: "Urgente", variant: "urgent" };
+    case 0:  return { label: "Leve",    variant: "light" };
+    default: return { label: "—",       variant: "cancelled" };
   }
 }
 

--- a/front/operator-web/src/hooks/analytics/useHistory.ts
+++ b/front/operator-web/src/hooks/analytics/useHistory.ts
@@ -1,81 +1,30 @@
-import { useEffect, useState } from "react";
-import { BASE_URL } from "@/lib/api/config";
+import { useMemo } from "react";
 import type { PillVariant } from "../../components/shared/Pill";
 import type { Period } from "./useAnalytics";
+import { useEmergencyStream } from "./useEmergencyStream";
+import type { BackendEmergency, BackendTriage } from "./emergencyStream";
 
 export interface PillData { label: string; variant: PillVariant }
 
 export interface HistoryRow {
-  id:          string;
-  date:        string;
-  operator:    string;
-  opTriage:    PillData;
-  assigned:    string;
-  accepted:    string;
-  tArrival:    string;
-  siteTriage:  PillData;
-  hospital:    string;
-  tHospital:   string;
-  delivery:    PillData;
-  tTotal:      string;
+  id:         string;
+  date:       string;
+  operator:   string;
+  opTriage:   PillData;
+  assigned:   string;
+  tArrival:   string;
+  siteTriage: PillData;
+  hospital:   string;
+  tHospital:  string;
+  delivery:   PillData;
+  tTotal:     string;
 }
 
-// ---------------------------------------------------------------------------
-// Mock data — shown when backend is unavailable or user is not ANALYST.
-// ---------------------------------------------------------------------------
-
-const PRIORITY: PillData[] = [
-  { label: "Crítico", variant: "critical" },
-  { label: "Urgente", variant: "urgent"   },
-  { label: "Leve",    variant: "light"    },
-];
-const SITE_TRIAGE: PillData[] = [
-  { label: "Crítico",   variant: "critical"  },
-  { label: "Estable",   variant: "stable"    },
-  { label: "Cancelado", variant: "cancelled" },
-  { label: "En sitio",  variant: "onsite"    },
-];
-const DELIVERY: PillData[] = [
-  { label: "Entregado", variant: "delivered" },
-  { label: "Cancelado", variant: "cancelled" },
-];
-
-const OPERATORS  = ["Juan Martínez", "Laura Gómez", "Carlos Restrepo", "Ana Pérez", "Pedro López"];
-const PARAMEDICS = ["M. Henao", "D. Sánchez", "J. Rojas", "S. Cárdenas", "R. Vélez", "F. Ortiz", "L. Quintero"];
-const HOSPITALS  = ["H. San Vicente", "Clínica Las Vegas", "H. Pablo Tobón", "Clínica El Rosario", "H. General", "Clínica Medellín"];
-
-function rng(seed: number) { let s = seed; return () => (s = (s * 9301 + 49297) % 233280) / 233280; }
-
-const MOCK_HISTORY: HistoryRow[] = (() => {
-  const r = rng(7);
-  return Array.from({ length: 24 }).map((_, i) => {
-    const id      = `EM-${String(2890 - i).padStart(4, "0")}`;
-    const opTri   = PRIORITY[Math.floor(r() * 3)];
-    const siteTri = SITE_TRIAGE[Math.floor(r() * SITE_TRIAGE.length)];
-    const cancelled = siteTri.label === "Cancelado";
-    const delivery = cancelled ? DELIVERY[1] : DELIVERY[Math.floor(r() * 2)];
-    const tArr   = `${4 + Math.floor(r() * 8)}m ${Math.floor(r() * 60)}s`;
-    const tHosp  = cancelled ? "—" : `${10 + Math.floor(r() * 30)}m`;
-    const tTotal = cancelled ? `${5 + Math.floor(r() * 8)}m` : `${18 + Math.floor(r() * 25)}m`;
-    const dateD  = String(28 - Math.floor(i / 3)).padStart(2, "0");
-    const dateH  = (8 + Math.floor(r() * 12)).toString().padStart(2, "0");
-    const dateM  = Math.floor(r() * 60).toString().padStart(2, "0");
-    return {
-      id,
-      date:       `${dateD}/05 ${dateH}:${dateM}`,
-      operator:   OPERATORS[Math.floor(r() * OPERATORS.length)],
-      opTriage:   opTri,
-      assigned:   PARAMEDICS[Math.floor(r() * PARAMEDICS.length)],
-      accepted:   PARAMEDICS[Math.floor(r() * PARAMEDICS.length)],
-      tArrival:   tArr,
-      siteTriage: siteTri,
-      hospital:   cancelled ? "—" : HOSPITALS[Math.floor(r() * HOSPITALS.length)],
-      tHospital:  tHosp,
-      delivery,
-      tTotal,
-    };
-  });
-})();
+export interface HistoryState {
+  loading: boolean;
+  rows:    HistoryRow[];
+  error:   string | null;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -114,14 +63,6 @@ function fmtDate(iso?: string): string {
   return `${day}/${mon} ${h}:${min}`;
 }
 
-interface BackendTriage {
-  bleeding?: boolean;
-  unconscious?: boolean;
-  difficulty_breathing?: boolean;
-  chest_pain?: boolean;
-  [key: string]: boolean | undefined;
-}
-
 function triageToPriority(triage: BackendTriage | null): PillData {
   if (!triage) return { label: "Leve", variant: "light" };
   if (triage.unconscious || triage.difficulty_breathing || triage.chest_pain) {
@@ -141,17 +82,6 @@ function finalStatusToSiteTriage(status: string): PillData {
   }
 }
 
-interface BackendEmergency {
-  id: string;
-  filingNumber?: number;
-  triage?: BackendTriage | null;
-  finalStatus?: string;
-  assignedTo?: { name?: string } | null;
-  transferedTo?: { name?: string } | null;
-  cancelReason?: string | null;
-  timeline?: Record<string, string>;
-}
-
 function mapBackendEmergency(e: BackendEmergency): HistoryRow {
   const tl = e.timeline ?? {};
   const canceled = e.finalStatus === "CANCELED";
@@ -162,10 +92,9 @@ function mapBackendEmergency(e: BackendEmergency): HistoryRow {
   return {
     id:         `EM-${String(e.filingNumber ?? 0).padStart(4, "0")}`,
     date:       fmtDate(tl["RECEIVED"]),
-    operator:   "Operador",
+    operator:   e.operatedBy?.name ?? "—",
     opTriage:   triageToPriority(e.triage ?? null),
     assigned:   e.assignedTo?.name ?? "—",
-    accepted:   e.assignedTo?.name ?? "—",
     tArrival:   fmtDiffSeconds(tl["ASSIGNED"], tl["ON_SITE"]),
     siteTriage: finalStatusToSiteTriage(e.finalStatus ?? ""),
     hospital:   e.transferedTo?.name ?? "—",
@@ -175,54 +104,9 @@ function mapBackendEmergency(e: BackendEmergency): HistoryRow {
   };
 }
 
-async function fetchHistory(
-  token: string,
-  since: string,
-  to: string,
-): Promise<HistoryRow[]> {
-  const url = `${BASE_URL}/api/v1/historic/emergency?since=${encodeURIComponent(since)}&to=${encodeURIComponent(to)}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`history fetch failed: ${res.status}`);
-
-  const text = await res.text();
-  const rows: HistoryRow[] = [];
-
-  // Handle both NDJSON (one object per line) and JSON array.
-  if (text.trimStart().startsWith("[")) {
-    const arr = JSON.parse(text) as BackendEmergency[];
-    return arr.map(mapBackendEmergency);
-  }
-
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      rows.push(mapBackendEmergency(JSON.parse(trimmed) as BackendEmergency));
-    } catch {
-      // skip malformed lines
-    }
-  }
-  return rows;
-}
-
-export function useHistory(period: Period, token?: string): HistoryRow[] {
-  const [rows, setRows] = useState<HistoryRow[]>(MOCK_HISTORY);
-
-  useEffect(() => {
-    if (!token) return;
-    const { since, to } = periodToRange(period);
-    let cancelled = false;
-    fetchHistory(token, since, to)
-      .then((r) => {
-        if (!cancelled) setRows(r.length > 0 ? r : MOCK_HISTORY);
-      })
-      .catch(() => {
-        if (!cancelled) setRows(MOCK_HISTORY);
-      });
-    return () => { cancelled = true; };
-  }, [period, token]);
-
-  return rows;
+export function useHistory(period: Period, token?: string): HistoryState {
+  const { since, to } = useMemo(() => periodToRange(period), [period]);
+  const { loading, emergencies, error } = useEmergencyStream(since, to, token);
+  const rows = useMemo(() => emergencies.map(mapBackendEmergency), [emergencies]);
+  return { loading, rows, error };
 }

--- a/front/operator-web/src/hooks/analytics/useHistory.ts
+++ b/front/operator-web/src/hooks/analytics/useHistory.ts
@@ -63,6 +63,13 @@ function fmtDate(iso?: string): string {
   return `${day}/${mon} ${h}:${min}`;
 }
 
+/** Epoch ms of the emergency's RECEIVED event (its creation time).
+ *  Emergencies without a RECEIVED entry get 0 so they sort last. */
+function receivedTime(e: BackendEmergency): number {
+  const iso = e.timeline?.["RECEIVED"];
+  return iso ? new Date(iso).getTime() : 0;
+}
+
 function triageToPriority(triage: BackendTriage | null): PillData {
   if (!triage) return { label: "Leve", variant: "light" };
   if (triage.unconscious || triage.difficulty_breathing || triage.chest_pain) {
@@ -110,6 +117,14 @@ function mapBackendEmergency(e: BackendEmergency): HistoryRow {
 export function useHistory(period: Period, token?: string): HistoryState {
   const { since, to } = useMemo(() => periodToRange(period), [period]);
   const { loading, emergencies, error } = useEmergencyStream(since, to, token);
-  const rows = useMemo(() => emergencies.map(mapBackendEmergency), [emergencies]);
+  const rows = useMemo(() => {
+    // Newest first: order by the RECEIVED event (creation time) descending.
+    // Sorting happens on the raw data because HistoryRow.date is a
+    // year-less "dd/mm hh:mm" string and cannot be ordered reliably.
+    const ordered = [...emergencies].sort(
+      (a, b) => receivedTime(b) - receivedTime(a),
+    );
+    return ordered.map(mapBackendEmergency);
+  }, [emergencies]);
   return { loading, rows, error };
 }

--- a/front/operator-web/src/hooks/analytics/useHistory.ts
+++ b/front/operator-web/src/hooks/analytics/useHistory.ts
@@ -72,13 +72,16 @@ function triageToPriority(triage: BackendTriage | null): PillData {
   return { label: "Leve", variant: "light" };
 }
 
-function finalStatusToSiteTriage(status: string): PillData {
-  switch (status) {
-    case "CANCELED": return { label: "Cancelado", variant: "cancelled" };
-    case "CLOSED":
-    case "IN_TRANSFER": return { label: "Estable",   variant: "stable" };
-    case "ON_SITE":     return { label: "En sitio",  variant: "onsite" };
-    default:            return { label: "Crítico",   variant: "critical" };
+/** Maps the paramedic's on-site complexity retriage to a pill.
+ *  `complexityLevel` is the backend ComplexityLevel enum: 0 BASIC,
+ *  1 INTERMEDIATE, 2 HIGH. `null`/undefined means the paramedic never
+ *  retriaged the emergency (e.g. it was canceled before their arrival). */
+function complexityToSiteTriage(level?: number | null): PillData {
+  switch (level) {
+    case 2:  return { label: "Alto",       variant: "critical" };
+    case 1:  return { label: "Intermedio", variant: "urgent" };
+    case 0:  return { label: "Básico",     variant: "light" };
+    default: return { label: "—",          variant: "cancelled" };
   }
 }
 
@@ -96,7 +99,7 @@ function mapBackendEmergency(e: BackendEmergency): HistoryRow {
     opTriage:   triageToPriority(e.triage ?? null),
     assigned:   e.assignedTo?.name ?? "—",
     tArrival:   fmtDiffSeconds(tl["ASSIGNED"], tl["ON_SITE"]),
-    siteTriage: finalStatusToSiteTriage(e.finalStatus ?? ""),
+    siteTriage: complexityToSiteTriage(e.complexityLevel),
     hospital:   e.transferedTo?.name ?? "—",
     tHospital:  fmtDiffSeconds(tl["IN_TRANSFER"], tl["SOLVED"]),
     delivery,

--- a/front/operator-web/src/hooks/analytics/useHistory.ts
+++ b/front/operator-web/src/hooks/analytics/useHistory.ts
@@ -100,7 +100,7 @@ function mapBackendEmergency(e: BackendEmergency): HistoryRow {
     : { label: "Entregado", variant: "delivered" };
 
   return {
-    id:         `EM-${String(e.filingNumber ?? 0).padStart(4, "0")}`,
+    id:         e.filingNumber != null ? String(e.filingNumber) : "—",
     date:       fmtDate(tl["RECEIVED"]),
     operator:   e.operatedBy?.name ?? "—",
     opTriage:   triageToPriority(e.triage ?? null),

--- a/front/operator-web/src/hooks/analytics/useTopLocations.ts
+++ b/front/operator-web/src/hooks/analytics/useTopLocations.ts
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { reverseGeocodeAddress, type ReverseAddress } from "../../map/geocoding";
+
+export interface TopLocation {
+  rank:   number;
+  label:  string;
+  count:  number;
+  weight: number;
+}
+
+export interface TopLocationsState {
+  loading: boolean;
+  rows:    TopLocation[];
+}
+
+const STORAGE_KEY    = "siee:heatmap-geocode:v1";
+const REQUEST_GAP_MS = 1100;
+
+const memCache: Map<string, ReverseAddress> = loadCacheFromStorage();
+
+function loadCacheFromStorage(): Map<string, ReverseAddress> {
+  const map = new Map<string, ReverseAddress>();
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return map;
+    const obj = JSON.parse(raw) as Record<string, ReverseAddress>;
+    for (const [k, v] of Object.entries(obj)) map.set(k, v);
+  } catch {
+    // Ignore corrupted storage — start fresh.
+  }
+  return map;
+}
+
+function flushCacheToStorage(): void {
+  try {
+    const obj: Record<string, ReverseAddress> = {};
+    memCache.forEach((v, k) => { obj[k] = v; });
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(obj));
+  } catch {
+    // Storage full or disabled — silently ignore; in-memory cache still works.
+  }
+}
+
+function pointKey(lat: number, lng: number): string {
+  return `${lat.toFixed(5)},${lng.toFixed(5)}`;
+}
+
+function bucketLabel(addr: ReverseAddress): string {
+  return addr.road ?? addr.suburb ?? "Sin nombre";
+}
+
+interface Bucket { count: number; weight: number }
+
+function aggregate(
+  points: [number, number, number][],
+  resolved: Map<string, ReverseAddress>,
+): TopLocation[] {
+  const buckets = new Map<string, Bucket>();
+  for (const [lat, lng, intensity] of points) {
+    const addr = resolved.get(pointKey(lat, lng));
+    if (!addr) continue;
+    const label = bucketLabel(addr);
+    const b = buckets.get(label) ?? { count: 0, weight: 0 };
+    b.count  += 1;
+    b.weight += intensity;
+    buckets.set(label, b);
+  }
+  const sorted = [...buckets.entries()].sort((a, b) => {
+    if (b[1].count !== a[1].count) return b[1].count - a[1].count;
+    return b[1].weight - a[1].weight;
+  });
+  return sorted.slice(0, 5).map(([label, b], i) => ({
+    rank:   i + 1,
+    label,
+    count:  b.count,
+    weight: b.weight,
+  }));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export function useTopLocations(
+  points: [number, number, number][],
+): TopLocationsState {
+  const [state, setState] = useState<TopLocationsState>({ loading: true, rows: [] });
+
+  useEffect(() => {
+    let cancelled = false;
+    const resolved = new Map<string, ReverseAddress>();
+
+    for (const [lat, lng] of points) {
+      const key = pointKey(lat, lng);
+      const hit = memCache.get(key);
+      if (hit) resolved.set(key, hit);
+    }
+
+    const pending = points.filter(([lat, lng]) => !resolved.has(pointKey(lat, lng)));
+
+    setState({ loading: pending.length > 0, rows: aggregate(points, resolved) });
+    if (pending.length === 0) return;
+
+    (async () => {
+      let dirty = false;
+      for (let i = 0; i < pending.length; i++) {
+        if (cancelled) return;
+        const [lat, lng] = pending[i];
+        const key = pointKey(lat, lng);
+
+        const addr = await reverseGeocodeAddress(lat, lng);
+        if (cancelled) return;
+
+        if (addr) {
+          memCache.set(key, addr);
+          resolved.set(key, addr);
+          dirty = true;
+          setState({
+            loading: i < pending.length - 1,
+            rows:    aggregate(points, resolved),
+          });
+        } else if (i === pending.length - 1) {
+          setState((s) => ({ ...s, loading: false }));
+        }
+
+        if (i < pending.length - 1) await delay(REQUEST_GAP_MS);
+      }
+      if (dirty) flushCacheToStorage();
+    })();
+
+    return () => { cancelled = true; };
+  }, [points]);
+
+  return state;
+}

--- a/front/operator-web/src/map/geocoding.ts
+++ b/front/operator-web/src/map/geocoding.ts
@@ -59,3 +59,48 @@ export async function reverseGeocode(
     return null;
   }
 }
+
+export interface ReverseAddress {
+  road:          string | null;
+  suburb:        string | null;
+  neighbourhood: string | null;
+  city:          string | null;
+}
+
+/**
+ * Reverse geocoding que devuelve los componentes parseados del campo
+ * `address` de Nominatim, no solo `display_name`. Útil cuando se quiere
+ * agrupar por calle/sector en vez de mostrar una dirección completa.
+ * Devuelve `null` ante cualquier fallo de red/parseo.
+ */
+export async function reverseGeocodeAddress(
+  latitude: number,
+  longitude: number,
+): Promise<ReverseAddress | null> {
+  try {
+    const url =
+      `${NOMINATIM}/reverse?lat=${latitude}&lon=${longitude}` +
+      `&format=jsonv2&addressdetails=1`;
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      address?: {
+        road?:          string;
+        suburb?:        string;
+        neighbourhood?: string;
+        city?:          string;
+        town?:          string;
+        village?:       string;
+      };
+    };
+    const a = data.address ?? {};
+    return {
+      road:          a.road          ?? null,
+      suburb:        a.suburb        ?? null,
+      neighbourhood: a.neighbourhood ?? null,
+      city:          a.city ?? a.town ?? a.village ?? null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/front/operator-web/src/map/heatmapLeafletHtml.ts
+++ b/front/operator-web/src/map/heatmapLeafletHtml.ts
@@ -1,6 +1,7 @@
 /**
  * Builds a self-contained HTML document (suitable for iframe srcDoc) that
- * renders a Leaflet heatmap over Envigado using circleMarkers.
+ * renders a Leaflet heatmap over Envigado using the leaflet.heat plugin
+ * on top of OpenStreetMap tiles.
  *
  * Points are anonymised aggregate locations — no citizen-identifiable data.
  * postMessage is not required; the map is purely visual / read-only.
@@ -16,31 +17,31 @@ export function buildHeatmapHtml(
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"><\/script>
+  <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"><\/script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body, #map { height: 100%; width: 100%; }
+    .leaflet-control-attribution { font-size: 10px; }
   </style>
 </head>
 <body>
 <div id="map"></div>
 <script>
   var points = ${pointsJson};
-  var map = L.map('map', { zoomControl: false, attributionControl: false })
+  var map = L.map('map', { zoomControl: false })
     .setView([6.1700, -75.5890], 14);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
   }).addTo(map);
   L.control.zoom({ position: 'topright' }).addTo(map);
-  points.forEach(function(p) {
-    var lat = p[0], lng = p[1], intensity = p[2];
-    var hue = 30 + (1 - intensity) * 60;
-    L.circleMarker([lat, lng], {
-      radius: intensity * 26 + 8,
-      fillColor: 'oklch(0.65 0.2 ' + hue + ')',
-      fillOpacity: 0.35 + intensity * 0.3,
-      stroke: false,
-    }).addTo(map);
-  });
+  L.heatLayer(points, {
+    radius: 30,
+    blur: 25,
+    maxZoom: 17,
+    minOpacity: 0.35,
+    gradient: { 0.2: '#43a047', 0.5: '#fbc02d', 0.8: '#fb8c00', 1.0: '#e53935' }
+  }).addTo(map);
   setTimeout(function() { map.invalidateSize(); }, 100);
 <\/script>
 </body>

--- a/front/operator-web/src/views/AnalyticsDashboard.tsx
+++ b/front/operator-web/src/views/AnalyticsDashboard.tsx
@@ -15,24 +15,27 @@ interface Props {
 }
 
 export default function AnalyticsDashboard({ token }: Props) {
-  const [view,   setView]   = useState<AnalyticsView>("analytics");
-  const [period, setPeriod] = useState<Period>("month");
-  const data = useAnalytics(period, token);
+  const [view,            setView]            = useState<AnalyticsView>("analytics");
+  const [analyticsPeriod, setAnalyticsPeriod] = useState<Period>("month");
+  const [historyPeriod,   setHistoryPeriod]   = useState<Period>("month");
+  const data = useAnalytics(analyticsPeriod, token);
 
   return (
     <div className="flex-1 flex flex-col min-w-0 overflow-hidden bg-op-bg">
       <AnalyticsTopBar
         view={view}
         onViewChange={setView}
-        period={period}
-        onPeriodChange={setPeriod}
+        analyticsPeriod={analyticsPeriod}
+        onAnalyticsPeriodChange={setAnalyticsPeriod}
+        historyPeriod={historyPeriod}
+        onHistoryPeriodChange={setHistoryPeriod}
       />
 
       <div className="flex-1 overflow-y-auto p-5">
         {view === "history" ? (
-          <HistoryView period={period} token={token} />
+          <HistoryView period={historyPeriod} token={token} />
         ) : view === "heatmap" ? (
-          <HeatMapView points={data.heatmapPoints} />
+          <HeatMapView token={token} />
         ) : (
           <>
             {/* KPI row */}
@@ -45,7 +48,7 @@ export default function AnalyticsDashboard({ token }: Props) {
             {/* Pipeline full-width card */}
             <Card
               title="Emergencias completadas"
-              subtitle={`${data.emergencyCount} este ${period === "today" ? "día" : period === "week" ? "semana" : period === "year" ? "año" : "mes"}`}
+              subtitle={`${data.emergencyCount} este ${analyticsPeriod === "today" ? "día" : analyticsPeriod === "week" ? "semana" : analyticsPeriod === "year" ? "año" : "mes"}`}
               className="mb-4"
             >
               <StackedPipelineBar stages={data.pipeline} />

--- a/front/operator-web/src/views/AnalyticsDashboard.tsx
+++ b/front/operator-web/src/views/AnalyticsDashboard.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { useAnalytics, type Period } from "../hooks/analytics/useAnalytics";
 import AnalyticsTopBar, { type AnalyticsView } from "../components/analytics/AnalyticsTopBar";
 import HistoryView from "./HistoryView";
+import HeatMapView from "./HeatMapView";
 import Card               from "../components/analytics/Card";
 import KpiCard            from "../components/analytics/KpiCard";
 import StackedPipelineBar from "../components/analytics/StackedPipelineBar";
 import TrendChart         from "../components/analytics/TrendChart";
 import OperatorsTable     from "../components/analytics/OperatorsTable";
 import ComparativeCard    from "../components/analytics/ComparativeCard";
-import HeatMap            from "../components/analytics/HeatMap";
 
 interface Props {
   token?: string;
@@ -31,6 +31,8 @@ export default function AnalyticsDashboard({ token }: Props) {
       <div className="flex-1 overflow-y-auto p-5">
         {view === "history" ? (
           <HistoryView period={period} token={token} />
+        ) : view === "heatmap" ? (
+          <HeatMapView points={data.heatmapPoints} />
         ) : (
           <>
             {/* KPI row */}
@@ -49,30 +51,20 @@ export default function AnalyticsDashboard({ token }: Props) {
               <StackedPipelineBar stages={data.pipeline} />
             </Card>
 
-            {/* Bottom: left column 420px + heatmap flex-1 */}
-            <div className="grid [grid-template-columns:420px_1fr] gap-4">
-              <div className="flex flex-col gap-4">
-                <Card title="Tendencia de emergencias">
-                  <TrendChart trends={data.trends} />
-                </Card>
-
-                <Card
-                  title="Ciudadanos atendidos por operador"
-                  subtitle={`${data.operators.length} operadores`}
-                >
-                  <OperatorsTable operators={data.operators} />
-                </Card>
-
-                <ComparativeCard items={data.comparative} />
-              </div>
+            {/* 3 equal columns: trend / operators / comparative */}
+            <div className="grid grid-cols-3 gap-4">
+              <Card title="Tendencia de emergencias">
+                <TrendChart trends={data.trends} />
+              </Card>
 
               <Card
-                title="Mapa de calor"
-                subtitle="Zonas con más emergencias — Envigado"
-                className="flex flex-col"
+                title="Ciudadanos atendidos por operador"
+                subtitle={`${data.operators.length} operadores`}
               >
-                <HeatMap points={data.heatmapPoints} />
+                <OperatorsTable operators={data.operators} />
               </Card>
+
+              <ComparativeCard items={data.comparative} />
             </div>
           </>
         )}

--- a/front/operator-web/src/views/AnalyticsDashboard.tsx
+++ b/front/operator-web/src/views/AnalyticsDashboard.tsx
@@ -18,7 +18,7 @@ export default function AnalyticsDashboard({ token }: Props) {
   const [view,            setView]            = useState<AnalyticsView>("analytics");
   const [analyticsPeriod, setAnalyticsPeriod] = useState<Period>("month");
   const [historyPeriod,   setHistoryPeriod]   = useState<Period>("month");
-  const data = useAnalytics(analyticsPeriod, token);
+  const { loading, data, error } = useAnalytics(analyticsPeriod, token);
 
   return (
     <div className="flex-1 flex flex-col min-w-0 overflow-hidden bg-op-bg">
@@ -36,6 +36,16 @@ export default function AnalyticsDashboard({ token }: Props) {
           <HistoryView period={historyPeriod} token={token} />
         ) : view === "heatmap" ? (
           <HeatMapView token={token} />
+        ) : loading && !data ? (
+          <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border animate-pulse" />
+        ) : error && !data ? (
+          <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border flex items-center justify-center text-[13px] text-op-text-ter">
+            No se pudieron cargar los datos de analítica
+          </div>
+        ) : !data ? (
+          <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border flex items-center justify-center text-[13px] text-op-text-ter">
+            Sin datos disponibles
+          </div>
         ) : (
           <>
             {/* KPI row */}
@@ -51,7 +61,7 @@ export default function AnalyticsDashboard({ token }: Props) {
               subtitle={`${data.emergencyCount} este ${analyticsPeriod === "today" ? "día" : analyticsPeriod === "week" ? "semana" : analyticsPeriod === "year" ? "año" : "mes"}`}
               className="mb-4"
             >
-              <StackedPipelineBar stages={data.pipeline} />
+              <StackedPipelineBar stages={data.pipeline} stdev={data.stdev} />
             </Card>
 
             {/* 3 equal columns: trend / operators / comparative */}

--- a/front/operator-web/src/views/AnalyticsDashboard.tsx
+++ b/front/operator-web/src/views/AnalyticsDashboard.tsx
@@ -67,7 +67,7 @@ export default function AnalyticsDashboard({ token }: Props) {
             {/* 3 equal columns: trend / operators / comparative */}
             <div className="grid grid-cols-3 gap-4">
               <Card title="Tendencia de emergencias">
-                <TrendChart trends={data.trends} />
+                <TrendChart trend={data.trend} />
               </Card>
 
               <Card

--- a/front/operator-web/src/views/HeatMapView.tsx
+++ b/front/operator-web/src/views/HeatMapView.tsx
@@ -15,25 +15,31 @@ export default function HeatMapView({ token }: Props) {
   const hasData = points.length > 0;
 
   return (
-    // Two columns side by side: heatmap at 70%, top locations at 30%.
-    <div className="grid grid-cols-[7fr_3fr] gap-4">
+    // Responsive layout:
+    //  - <lg (≤1023px): one column; map on top, Top 5 below.
+    //  - ≥lg: two columns side by side, map at 80% / Top at 20%.
+    // `items-start` keeps the Top 5 card hugging its content instead of
+    // stretching to match the taller heatmap card on wide screens.
+    // The map height also scales with breakpoint so it stays usable on
+    // tablets and a comfortable size on desktop.
+    <div className="grid grid-cols-1 lg:grid-cols-[8fr_2fr] gap-4 lg:items-start">
       <Card
         title="Mapa de calor"
         subtitle="Zonas con más emergencias — Envigado"
         className="flex flex-col"
       >
         {loading && !hasData && (
-          <div className="h-[560px] rounded-lg bg-op-bg animate-pulse" />
+          <div className="h-[420px] md:h-[560px] lg:h-[720px] rounded-lg bg-op-bg animate-pulse" />
         )}
 
         {!loading && error && (
-          <div className="h-[560px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
+          <div className="h-[420px] md:h-[560px] lg:h-[720px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
             No se pudieron cargar los datos del mapa
           </div>
         )}
 
         {!loading && !error && !hasData && (
-          <div className="h-[560px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
+          <div className="h-[420px] md:h-[560px] lg:h-[720px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
             Sin datos disponibles
           </div>
         )}

--- a/front/operator-web/src/views/HeatMapView.tsx
+++ b/front/operator-web/src/views/HeatMapView.tsx
@@ -1,18 +1,27 @@
 import Card from "../components/analytics/Card";
 import HeatMap from "../components/analytics/HeatMap";
+import TopLocationsList from "../components/analytics/TopLocationsList";
+import { useTopLocations } from "../hooks/analytics/useTopLocations";
 
 interface Props {
   points: [number, number, number][];
 }
 
 export default function HeatMapView({ points }: Props) {
+  const topLocations = useTopLocations(points);
+
   return (
-    <Card
-      title="Mapa de calor"
-      subtitle="Zonas con más emergencias — Envigado"
-      className="flex flex-col h-full"
-    >
-      <HeatMap points={points} />
-    </Card>
+    <div className="flex flex-col gap-4">
+      <Card
+        title="Mapa de calor"
+        subtitle="Zonas con más emergencias — Envigado"
+        className="flex flex-col"
+      >
+        <HeatMap points={points} />
+      </Card>
+      <Card>
+        <TopLocationsList state={topLocations} />
+      </Card>
+    </div>
   );
 }

--- a/front/operator-web/src/views/HeatMapView.tsx
+++ b/front/operator-web/src/views/HeatMapView.tsx
@@ -15,7 +15,8 @@ export default function HeatMapView({ token }: Props) {
   const hasData = points.length > 0;
 
   return (
-    <div className="flex flex-col gap-4">
+    // Two columns side by side: heatmap at 70%, top locations at 30%.
+    <div className="grid grid-cols-[7fr_3fr] gap-4">
       <Card
         title="Mapa de calor"
         subtitle="Zonas con más emergencias — Envigado"
@@ -40,11 +41,9 @@ export default function HeatMapView({ token }: Props) {
         {hasData && <HeatMap points={points} />}
       </Card>
 
-      {hasData && (
-        <Card>
-          <TopLocationsList state={topLocations} />
-        </Card>
-      )}
+      <Card>
+        <TopLocationsList state={topLocations} />
+      </Card>
     </div>
   );
 }

--- a/front/operator-web/src/views/HeatMapView.tsx
+++ b/front/operator-web/src/views/HeatMapView.tsx
@@ -1,14 +1,18 @@
 import Card from "../components/analytics/Card";
 import HeatMap from "../components/analytics/HeatMap";
 import TopLocationsList from "../components/analytics/TopLocationsList";
+import { useHeatmap } from "../hooks/analytics/useHeatmap";
 import { useTopLocations } from "../hooks/analytics/useTopLocations";
 
 interface Props {
-  points: [number, number, number][];
+  token?: string;
 }
 
-export default function HeatMapView({ points }: Props) {
+export default function HeatMapView({ token }: Props) {
+  const { loading, points, error } = useHeatmap(token);
   const topLocations = useTopLocations(points);
+
+  const hasData = points.length > 0;
 
   return (
     <div className="flex flex-col gap-4">
@@ -17,11 +21,30 @@ export default function HeatMapView({ points }: Props) {
         subtitle="Zonas con más emergencias — Envigado"
         className="flex flex-col"
       >
-        <HeatMap points={points} />
+        {loading && !hasData && (
+          <div className="h-[560px] rounded-lg bg-op-bg animate-pulse" />
+        )}
+
+        {!loading && error && (
+          <div className="h-[560px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
+            No se pudieron cargar los datos del mapa
+          </div>
+        )}
+
+        {!loading && !error && !hasData && (
+          <div className="h-[560px] rounded-lg bg-op-bg flex items-center justify-center text-[13px] text-op-text-ter">
+            Sin datos disponibles
+          </div>
+        )}
+
+        {hasData && <HeatMap points={points} />}
       </Card>
-      <Card>
-        <TopLocationsList state={topLocations} />
-      </Card>
+
+      {hasData && (
+        <Card>
+          <TopLocationsList state={topLocations} />
+        </Card>
+      )}
     </div>
   );
 }

--- a/front/operator-web/src/views/HeatMapView.tsx
+++ b/front/operator-web/src/views/HeatMapView.tsx
@@ -1,0 +1,18 @@
+import Card from "../components/analytics/Card";
+import HeatMap from "../components/analytics/HeatMap";
+
+interface Props {
+  points: [number, number, number][];
+}
+
+export default function HeatMapView({ points }: Props) {
+  return (
+    <Card
+      title="Mapa de calor"
+      subtitle="Zonas con más emergencias — Envigado"
+      className="flex flex-col h-full"
+    >
+      <HeatMap points={points} />
+    </Card>
+  );
+}

--- a/front/operator-web/src/views/HistoryView.tsx
+++ b/front/operator-web/src/views/HistoryView.tsx
@@ -5,6 +5,28 @@ import type { Period } from "../hooks/analytics/useAnalytics";
 interface Props { period: Period; token?: string }
 
 export default function HistoryView({ period, token }: Props) {
-  const rows = useHistory(period, token);
+  const { loading, rows, error } = useHistory(period, token);
+  const hasData = rows.length > 0;
+
+  if (loading && !hasData) {
+    return <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border animate-pulse" />;
+  }
+
+  if (!loading && error) {
+    return (
+      <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border flex items-center justify-center text-[13px] text-op-text-ter">
+        No se pudieron cargar los registros
+      </div>
+    );
+  }
+
+  if (!loading && !error && !hasData) {
+    return (
+      <div className="h-[560px] rounded-[10px] bg-op-surface border border-op-border flex items-center justify-center text-[13px] text-op-text-ter">
+        Sin registros en este período
+      </div>
+    );
+  }
+
   return <HistoryTable rows={rows} />;
 }


### PR DESCRIPTION
@
Brings the operator-web analytics dashboard onto live backend data and fixes the four issues raised on the histórico/heatmap view.

## Highlights

**Backend**
- `feat(core): persist paramedic complexity level in historical emergency` — `HistoricalEmergency` now carries `complexityLevel`, copied from `Emergency.complexityLevel` in `from_emergency`. Without this the paramedic on-site retriage was lost on archival and the histórico had no way to show it. Covered by two tests in `back/core/src/core/domain/tests/test_historical_emergency.py`.

**Operator web — analytics wiring**
- Heatmap, history and trends now consume real data from `GET /api/v1/historic/emergency` through a shared `useEmergencyStream` hook (`emergencyStream.ts`, `useEmergencyStream.ts`, `useHeatmap.ts`, `useTopLocations.ts`, `analyticsTrends.ts`).
- Analytics and history keep independent period state; trend chart syncs with the dashboard period selector.
- History pagination and layout updated to match the new data volume.

**Operator web — four requested fixes**
- **Histórico ordered newest first** — sort by the `RECEIVED` timeline event before mapping to rows (`useHistory.ts`).
- **Heatmap layout** — map left at 70% / Top 5 right at 30% via `grid-cols-[7fr_3fr]` (`HeatMapView.tsx`).
- **Triaje sitio shows the paramedic retriage** — new `complexityToSiteTriage` mapping `complexityLevel` 0/1/2 to "Leve / Urgente / Crítico", sharing the operator-triage vocabulary so both columns compare at a glance. `null` (cancelled before retriage) renders as "—".
- **Radicado without "EM-" prefix** — filing number rendered as the raw numeric series.

## Notes
- 18 commits, 35 files, +1110/-779.
- Branch is currently 7 commits behind `main`; happy to rebase before merge if preferred.

@